### PR TITLE
Make initial build phase tick-able (and replay-able). Replay game functionality.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,6 @@ class MyPlayer(Player):
             playable_actions (Iterable[Action]): options right now
         """
         raise NotImplementedError
-
-    def discard(self):
-        """Must return n/2 cards to discard from self.resource_deck"""
-        raise NotImplementedError
 ```
 
 ## Running and Watching a Game

--- a/catanatron/game.py
+++ b/catanatron/game.py
@@ -16,6 +16,7 @@ from catanatron.models.actions import (
     settlement_possible_actions,
     robber_possibilities,
     year_of_plenty_possible_actions,
+    monopoly_possible_actions,
 )
 from catanatron.models.player import Player
 from catanatron.models.decks import ResourceDeck, DevelopmentDeck
@@ -326,6 +327,7 @@ class Game:
                         number_of_cards_to_steal, card_type_to_steal
                     )
             player_to_act.resource_deck += cards_stolen
+            player_to_act.development_deck.draw(1, DevelopmentCard.MONOPOLY)
 
         else:
             raise RuntimeError("Unknown ActionType " + str(action.action_type))

--- a/catanatron/game.py
+++ b/catanatron/game.py
@@ -1,5 +1,8 @@
 import uuid
 import random
+import sys
+import copy
+from enum import Enum
 from typing import Iterable
 from collections import namedtuple, defaultdict
 
@@ -9,6 +12,7 @@ from catanatron.models.board import Board, BuildingType
 from catanatron.models.board_initializer import Node
 from catanatron.models.enums import Resource, DevelopmentCard
 from catanatron.models.actions import (
+    ActionPrompt,
     Action,
     ActionType,
     road_possible_actions,
@@ -17,6 +21,9 @@ from catanatron.models.actions import (
     robber_possibilities,
     year_of_plenty_possible_actions,
     monopoly_possible_actions,
+    initial_road_possibilities,
+    initial_settlement_possibilites,
+    discard_possibilities,
 )
 from catanatron.models.player import Player
 from catanatron.models.decks import ResourceDeck, DevelopmentDeck
@@ -73,15 +80,31 @@ def yield_resources(board, resource_deck, number):
     return payout, depleted
 
 
+def initialize_tick_queue(players):
+    """First player goes, settlement and road, ..."""
+    tick_queue = []
+    for player in players:
+        tick_queue.append((player, ActionPrompt.BUILD_FIRST_SETTLEMENT))
+        tick_queue.append((player, ActionPrompt.BUILD_INITIAL_ROAD))
+    for player in reversed(players):
+        tick_queue.append((player, ActionPrompt.BUILD_SECOND_SETTLEMENT))
+        tick_queue.append((player, ActionPrompt.BUILD_INITIAL_ROAD))
+    tick_queue.append((players[0], ActionPrompt.ROLL))
+    return tick_queue
+
+
 class Game:
     """
     This contains the complete state of the game (board + players) and the
     core turn-by-turn controlling logic.
     """
 
-    def __init__(self, players: Iterable[Player]):
+    def __init__(self, players: Iterable[Player], seed=None):
+        self.seed = seed or random.randrange(sys.maxsize)
+        random.seed(self.seed)
+
         self.id = str(uuid.uuid4())
-        self.players = players
+        self.players = random.sample(players, len(players))
         self.players_by_color = {p.color: p for p in players}
         self.map = BaseMap()
         self.board = Board(self.map)
@@ -89,69 +112,14 @@ class Game:
         self.resource_deck = ResourceDeck.starting_bank()
         self.development_deck = DevelopmentDeck.starting_bank()
 
-        # variables to keep track of what to do next
+        self.tick_queue = initialize_tick_queue(players)
         self.current_player_index = 0
-        self.current_player_has_roll = False
-        self.moving_robber = False
-        self.tick_queue = []
-        random.shuffle(self.players)
-
         self.num_turns = 0
 
     def play(self, action_callback=None):
         """Runs the game until the end"""
-        self.play_initial_build_phase(action_callback)
         while self.winning_player() == None and self.num_turns < TURNS_LIMIT:
             self.play_tick(action_callback)
-
-    def play_initial_build_phase(self, action_callback=None):
-        """First player goes, settlement and road, ..."""
-        for player in self.players + list(reversed(self.players)):
-            # Place a settlement first
-            buildable_nodes = self.board.buildable_nodes(
-                player.color, initial_build_phase=True
-            )
-            actions = map(
-                lambda node: Action(player, ActionType.BUILD_SETTLEMENT, node),
-                buildable_nodes,
-            )
-            action = player.decide(self, list(actions))
-            self.execute(
-                action, initial_build_phase=True, action_callback=action_callback
-            )
-
-            # Then a road, ensure its connected to this last settlement
-            buildable_edges = filter(
-                lambda e: action.value in e.nodes,
-                self.board.buildable_edges(player.color),
-            )
-            actions = map(
-                lambda edge: Action(player, ActionType.BUILD_ROAD, edge),
-                buildable_edges,
-            )
-            action = player.decide(self, list(actions))
-            self.execute(
-                action, initial_build_phase=True, action_callback=action_callback
-            )
-
-        # yield resources of second settlement
-        second_settlements = map(
-            lambda a: (a.player, a.value),
-            filter(
-                lambda a: a.action_type == ActionType.BUILD_SETTLEMENT,
-                self.actions[len(self.players) * 2 :],
-            ),
-        )
-        for (player, node) in second_settlements:
-            for tile in self.board.get_adjacent_tiles(node):
-                if tile.resource != None:
-                    player.resource_deck.replenish(1, tile.resource)
-
-        # TODO: For the robot to better learn, refactor this method to use .execute via
-        #   ActionType.BUILD_FIRST_SETTLEMENT and ActionType.BUILD_SECOND_SETTLEMENT.
-        #   So that it learns second settlement yields.
-        # if action_callback:
-        #     action_callback()
 
     def winning_player(self):
         for player in self.players:
@@ -166,70 +134,91 @@ class Game:
         If nothing there, fall back to (current, playable()) for current-turn.
         """
         if len(self.tick_queue) > 0:
-            (player, actions) = self.tick_queue.pop()
+            (player, action_prompt) = self.tick_queue.pop(0)
         else:
-            player = self.players[self.current_player_index]
-            actions = self.playable_actions(player)
+            (player, action_prompt) = (self.current_player(), ActionPrompt.PLAY_TURN)
+
+        actions = self.playable_actions(player, action_prompt)
         action = player.decide(self.board, actions)
         self.execute(action, action_callback=action_callback)
 
-    def playable_actions(self, player):
-        if self.moving_robber:
+    def playable_actions(self, player, action_prompt):
+        if action_prompt == ActionPrompt.BUILD_FIRST_SETTLEMENT:
+            return initial_settlement_possibilites(player, self.board, True)
+        elif action_prompt == ActionPrompt.BUILD_SECOND_SETTLEMENT:
+            return initial_settlement_possibilites(player, self.board, False)
+        elif action_prompt == ActionPrompt.BUILD_INITIAL_ROAD:
+            return initial_road_possibilities(player, self.board, self.actions)
+        elif action_prompt == ActionPrompt.MOVE_ROBBER:
             return robber_possibilities(player, self.board, self.players)
-
-        if not self.current_player_has_roll:
+        elif action_prompt == ActionPrompt.ROLL:
             actions = [Action(player, ActionType.ROLL, None)]
             if player.has_knight_card():  # maybe knight
                 # TODO: Change to PLAY_KNIGHT_CARD
                 actions.extend(robber_possibilities(player, self.board, self.players))
 
             return actions
-
-        actions = [Action(player, ActionType.END_TURN, None)]
-        for action in road_possible_actions(player, self.board):
-            actions.append(action)
-        for action in settlement_possible_actions(player, self.board):
-            actions.append(action)
-        for action in city_possible_actions(player, self.board):
-            actions.append(action)
-
-        # Can only do if the player has not already played a development card
-        if player.has_year_of_plenty_card():
-            for action in year_of_plenty_possible_actions(player, self.resource_deck):
+        elif action_prompt == ActionPrompt.DISCARD:
+            return discard_possibilities(player)
+        elif action_prompt == ActionPrompt.PLAY_TURN:
+            actions = [Action(player, ActionType.END_TURN, None)]
+            for action in road_possible_actions(player, self.board):
                 actions.append(action)
-        if player.has_monopoly_card():
-            for action in monopoly_possible_actions(player):
+            for action in settlement_possible_actions(player, self.board):
+                actions.append(action)
+            for action in city_possible_actions(player, self.board):
                 actions.append(action)
 
-        if (
-            player.resource_deck.includes(ResourceDeck.development_card_cost())
-            and self.development_deck.num_cards() > 0
-        ):
-            actions.append(Action(player, ActionType.BUY_DEVELOPMENT_CARD, None))
+            # TODO: Can only do if the player has not already played a development card
+            if player.has_year_of_plenty_card():
+                for action in year_of_plenty_possible_actions(
+                    player, self.resource_deck
+                ):
+                    actions.append(action)
+            if player.has_monopoly_card():
+                for action in monopoly_possible_actions(player):
+                    actions.append(action)
 
-        return actions
+            if (
+                player.resource_deck.includes(ResourceDeck.development_card_cost())
+                and self.development_deck.num_cards() > 0
+            ):
+                actions.append(Action(player, ActionType.BUY_DEVELOPMENT_CARD, None))
 
-    def execute(self, action, initial_build_phase=False, action_callback=None):
+            return actions
+        else:
+            raise RuntimeError("Unknown ActionPrompt")
+
+    def execute(self, action, action_callback=None):
         if action.action_type == ActionType.END_TURN:
-            self.current_player_index = (self.current_player_index + 1) % len(
-                self.players
-            )
-            self.current_player_has_roll = False
+            next_player_index = (self.current_player_index + 1) % len(self.players)
+            self.current_player_index = next_player_index
+            self.tick_queue.append((self.players[next_player_index], ActionPrompt.ROLL))
             self.num_turns += 1
+        elif action.action_type == ActionType.BUILD_FIRST_SETTLEMENT:
+            self.board.build_settlement(
+                action.player.color, action.value, initial_build_phase=True
+            )
+        elif action.action_type == ActionType.BUILD_SECOND_SETTLEMENT:
+            self.board.build_settlement(
+                action.player.color, action.value, initial_build_phase=True
+            )
+            # yield resources of second settlement
+            for tile in self.board.get_adjacent_tiles(action.value):
+                if tile.resource != None:
+                    action.player.resource_deck.replenish(1, tile.resource)
         elif action.action_type == ActionType.BUILD_SETTLEMENT:
             self.board.build_settlement(
-                action.player.color,
-                action.value,
-                initial_build_phase=initial_build_phase,
+                action.player.color, action.value, initial_build_phase=False
             )
-            if not initial_build_phase:
-                action.player.resource_deck -= ResourceDeck.settlement_cost()
-                self.resource_deck += ResourceDeck.settlement_cost()  # replenish bank
+            action.player.resource_deck -= ResourceDeck.settlement_cost()
+            self.resource_deck += ResourceDeck.settlement_cost()  # replenish bank
+        elif action.action_type == ActionType.BUILD_INITIAL_ROAD:
+            self.board.build_road(action.player.color, action.value)
         elif action.action_type == ActionType.BUILD_ROAD:
             self.board.build_road(action.player.color, action.value)
-            if not initial_build_phase:
-                action.player.resource_deck -= ResourceDeck.road_cost()
-                self.resource_deck += ResourceDeck.road_cost()  # replenish bank
+            action.player.resource_deck -= ResourceDeck.road_cost()
+            self.resource_deck += ResourceDeck.road_cost()  # replenish bank
         elif action.action_type == ActionType.BUILD_CITY:
             self.board.build_city(action.player.color, action.value)
             action.player.resource_deck -= ResourceDeck.city_cost()
@@ -243,12 +232,9 @@ class Game:
                     p for p in self.players if p.resource_deck.num_cards() > 7
                 ]
                 self.tick_queue.extend(
-                    [
-                        (p, [Action(p, ActionType.DISCARD, None)])
-                        for p in players_to_discard
-                    ]
+                    [(p, ActionPrompt.DISCARD) for p in players_to_discard]
                 )
-                self.moving_robber = True
+                self.tick_queue.append((action.player, ActionPrompt.MOVE_ROBBER))
             else:
                 payout, depleted = yield_resources(
                     self.board, self.resource_deck, number
@@ -261,27 +247,22 @@ class Game:
                     self.resource_deck -= resource_deck
 
             action = Action(action.player, action.action_type, dices)
-            self.current_player_has_roll = True
+            self.tick_queue.append((action.player, ActionPrompt.PLAY_TURN))
         elif action.action_type == ActionType.MOVE_ROBBER:
             (coordinate, player_to_steal_from) = action.value
             self.board.robber_coordinate = coordinate
             if player_to_steal_from is not None:
                 resource = player_to_steal_from.resource_deck.random_draw()
-                self.current_player().resource_deck.replenish(1, resource)
-
-            self.moving_robber = False
+                action.player.resource_deck.replenish(1, resource)
         elif action.action_type == ActionType.DISCARD:
-            num_cards = action.player.resource_deck.num_cards()
-            discarded = action.player.discard()
-            assert len(discarded) == num_cards // 2
+            discarded = action.value
 
             to_discard = ResourceDeck()
             for resource in discarded:
                 to_discard.replenish(1, resource)
+
             action.player.resource_deck -= to_discard
             self.resource_deck += to_discard
-
-            action = Action(action.player, action.action_type, discarded)
         elif action.action_type == ActionType.BUY_DEVELOPMENT_CARD:
             if self.development_deck.num_cards() == 0:
                 raise ValueError("No more development cards")
@@ -361,3 +342,28 @@ class Game:
             player.actual_victory_points = public_vps + player.development_deck.count(
                 DevelopmentCard.VICTORY_POINT
             )
+
+
+def replay_game(game):
+    game_copy = copy.deepcopy(game)
+
+    for player in game_copy.players:
+        player.public_victory_points = 0
+        player.actual_victory_points = 0
+        player.resource_deck = ResourceDeck()
+        player.development_deck = DevelopmentDeck()
+
+    tmp_game = Game(game_copy.players, seed=game.seed)
+    tmp_game.id = game_copy.id
+    tmp_game.players = game_copy.players  # use same seating order
+    tmp_game.map = game_copy.map
+    tmp_game.board = game_copy.board
+    tmp_game.board.buildings = {}
+    tmp_game.board.robber_coordinate = filter(
+        lambda coordinate: tmp_game.board.tiles[coordinate].resource == None,
+        tmp_game.board.tiles.keys(),
+    ).__next__()
+
+    for action in game_copy.actions:
+        tmp_game.execute(action)
+        yield tmp_game

--- a/catanatron/models/player.py
+++ b/catanatron/models/player.py
@@ -29,10 +29,6 @@ class Player:
         """
         raise NotImplementedError
 
-    def discard(self):
-        """Must return n/2 cards to discard from self.resource_deck"""
-        raise NotImplementedError
-
     def receive(self, resource_deck):
         self.resource_deck += resource_deck
 
@@ -45,21 +41,16 @@ class Player:
     def has_monopoly_card(self):
         return self.development_deck.count(DevelopmentCard.MONOPOLY) > 0
 
+    def __repr__(self):
+        return type(self).__name__ + "[" + self.color.value + "]"
+
 
 class SimplePlayer(Player):
     def decide(self, game, playable_actions):
         return playable_actions[0]
-
-    def discard(self):
-        cards = self.resource_deck.to_array()
-        return cards[: len(cards) // 2]
 
 
 class RandomPlayer(Player):
     def decide(self, game, playable_actions):
         index = random.randrange(0, len(playable_actions))
         return playable_actions[index]
-
-    def discard(self):
-        cards = self.resource_deck.to_array()
-        return random.sample(cards, len(cards) // 2)

--- a/database.py
+++ b/database.py
@@ -7,20 +7,31 @@ import psycopg2
 from catanatron.json import GameEncoder
 
 CREATE_TABLE_QUERY = """
-    CREATE TABLE IF NOT EXISTS games (
-        uuid            VARCHAR(36) NOT NULL UNIQUE, 
+    CREATE TABLE IF NOT EXISTS game_states (
+        id              SERIAL PRIMARY KEY,
+        game_id         VARCHAR(36) NOT NULL,
+        action_index    INTEGER, 
         state           JSON, 
-        pickle_data     BYTEA
+        pickle_data     BYTEA,
+
+        UNIQUE(game_id, action_index)
     )
     """
-UPSERT_GAME_QUERY = """
-    INSERT INTO games VALUES (%s, %s, %s)
-        ON CONFLICT(uuid) 
+INSERT_STATE_QUERY = """
+    INSERT INTO game_states (game_id, action_index, state, pickle_data) VALUES (%s, %s, %s, %s)
+    """
+UPSERT_STATE_QUERY = """
+    INSERT INTO game_states (game_id, action_index, state, pickle_data) VALUES (%s, %s, %s, %s)
+        ON CONFLICT(game_id, action_index) 
         DO UPDATE SET 
             state=excluded.state,
             pickle_data=excluded.pickle_data;
     """
-GET_GAME_QUERY = """SELECT pickle_data FROM games WHERE uuid = %s"""
+SELECT_GAME_QUERY = """
+    SELECT pickle_data FROM game_states 
+    WHERE game_id = %s ORDER BY action_index DESC LIMIT 1
+"""
+SELECT_GAMES_QUERY = """SELECT * FROM game_states"""
 
 connection = psycopg2.connect(
     user="catanatron",
@@ -32,20 +43,21 @@ connection = psycopg2.connect(
 cursor = connection.cursor()
 
 cursor.execute(CREATE_TABLE_QUERY)
+connection.commit()
 
 
-def save_game(uuid, game):
+def save_game_state(game):
     state = json.dumps(game, cls=GameEncoder)
     pickle_data = pickle.dumps(game, pickle.HIGHEST_PROTOCOL)
     cursor.execute(
-        UPSERT_GAME_QUERY,
-        (str(uuid), state, pickle_data),
+        INSERT_STATE_QUERY,
+        (game.id, len(game.actions), state, pickle_data),
     )
     connection.commit()
 
 
 def get_game(uuid):
-    cursor.execute(GET_GAME_QUERY, (uuid,))
+    cursor.execute(SELECT_GAME_QUERY, (uuid,))
     row = cursor.fetchone()
     if row is None:
         return None
@@ -53,3 +65,13 @@ def get_game(uuid):
     pickle_data = row[0]
     game = pickle.loads(pickle_data)
     return game
+
+
+def get_games():
+    cursor.execute(SELECT_GAMES_QUERY)
+    row = cursor.fetchone()
+    while row is not None:
+        pickle_data = row[2]
+        game = pickle.loads(pickle_data)
+        yield game
+        row = cursor.fetchone()

--- a/database.py
+++ b/database.py
@@ -78,10 +78,10 @@ def get_finished_games_ids():
 
 
 def get_game_states(game_id):
-    cursor.execute(SELECT_STATES_QUERY, (game_id))
+    cursor.execute(SELECT_STATES_QUERY, (game_id,))
     row = cursor.fetchone()
     while row is not None:
-        pickle_data = row[2]
+        pickle_data = row[4]
         game = pickle.loads(pickle_data)
         yield game
         row = cursor.fetchone()

--- a/database.py
+++ b/database.py
@@ -31,7 +31,8 @@ SELECT_GAME_QUERY = """
     SELECT pickle_data FROM game_states 
     WHERE game_id = %s ORDER BY action_index DESC LIMIT 1
 """
-SELECT_GAMES_QUERY = """SELECT * FROM game_states"""
+SELECT_GAME_IDS_QUERY = """SELECT DISTINCT game_id FROM game_states"""
+SELECT_STATES_QUERY = """SELECT * FROM game_states WHERE game_id = %s"""
 
 connection = psycopg2.connect(
     user="catanatron",
@@ -56,8 +57,8 @@ def save_game_state(game):
     connection.commit()
 
 
-def get_game(uuid):
-    cursor.execute(SELECT_GAME_QUERY, (uuid,))
+def get_last_game_state(game_id):
+    cursor.execute(SELECT_GAME_QUERY, (game_id,))
     row = cursor.fetchone()
     if row is None:
         return None
@@ -67,8 +68,17 @@ def get_game(uuid):
     return game
 
 
-def get_games():
-    cursor.execute(SELECT_GAMES_QUERY)
+# TODO: Filter by winners
+def get_finished_games_ids():
+    cursor.execute(SELECT_GAME_IDS_QUERY)
+    row = cursor.fetchone()
+    while row is not None:
+        yield row[0]
+        row = cursor.fetchone()
+
+
+def get_game_states(game_id):
+    cursor.execute(SELECT_STATES_QUERY, (game_id))
     row = cursor.fetchone()
     while row is not None:
         pickle_data = row[2]

--- a/play.py
+++ b/play.py
@@ -3,7 +3,7 @@ import json
 import uuid
 from pathlib import Path
 
-from database import save_game
+from database import save_game_state
 from catanatron.game import Game
 from catanatron.json import GameEncoder
 from catanatron.models.player import RandomPlayer, Color
@@ -15,13 +15,8 @@ game = Game(
         RandomPlayer(Color.BLUE),
         RandomPlayer(Color.WHITE),
         RandomPlayer(Color.ORANGE),
-    ]
+    ],
 )
-game.play()
+game.play(lambda g: save_game_state(g))
 print({p.color.value: p.actual_victory_points for p in game.players})
-
-print("Saving game...")
-game_id = str(uuid.uuid4())
-save_game(game_id, game)
-
-print("See result at http://localhost:3000/games/" + game_id)
+print("See result at http://localhost:3000/games/" + game.id)

--- a/play.py
+++ b/play.py
@@ -18,5 +18,6 @@ game = Game(
     ],
 )
 game.play()
+save_game_state(game)
 print({p.color.value: p.actual_victory_points for p in game.players})
 print("See result at http://localhost:3000/games/" + game.id)

--- a/play.py
+++ b/play.py
@@ -17,6 +17,6 @@ game = Game(
         RandomPlayer(Color.ORANGE),
     ],
 )
-game.play(lambda g: save_game_state(g))
+game.play()
 print({p.color.value: p.actual_victory_points for p in game.players})
 print("See result at http://localhost:3000/games/" + game.id)

--- a/server.py
+++ b/server.py
@@ -45,6 +45,7 @@ def tick_game(game_id):
     if game is None:
         abort(404, description="Resource not found")
 
-    game.play_tick()
+    if game.winning_player() is None:
+        game.play_tick()
     save_game(game_id, game)
     return json.dumps(game, cls=GameEncoder)

--- a/server.py
+++ b/server.py
@@ -4,7 +4,7 @@ import uuid
 from flask import Flask, jsonify, abort
 from flask_cors import CORS
 
-from database import save_game, get_game
+from database import save_game_state, get_game
 from catanatron.game import Game
 from catanatron.json import GameEncoder
 from catanatron.models.player import RandomPlayer, Color
@@ -24,10 +24,8 @@ def create_game():
             RandomPlayer(Color.ORANGE),
         ]
     )
-    game.play_initial_build_phase()
-    game_id = uuid.uuid4()
-    save_game(game_id, game)
-    return jsonify({"game_id": game_id})
+    game.play_initial_build_phase(lambda g: save_game_state(g))
+    return jsonify({"game_id": game.id})
 
 
 @app.route("/games/<string:game_id>", methods=["GET"])
@@ -46,6 +44,5 @@ def tick_game(game_id):
         abort(404, description="Resource not found")
 
     if game.winning_player() is None:
-        game.play_tick()
-    save_game(game_id, game)
+        game.play_tick(lambda g: save_game_state(g))
     return json.dumps(game, cls=GameEncoder)

--- a/server.py
+++ b/server.py
@@ -4,7 +4,7 @@ import uuid
 from flask import Flask, jsonify, abort
 from flask_cors import CORS
 
-from database import save_game_state, get_game
+from database import save_game_state, get_last_game_state
 from catanatron.game import Game
 from catanatron.json import GameEncoder
 from catanatron.models.player import RandomPlayer, Color
@@ -24,13 +24,13 @@ def create_game():
             RandomPlayer(Color.ORANGE),
         ]
     )
-    game.play_initial_build_phase(lambda g: save_game_state(g))
+    save_game_state(game)
     return jsonify({"game_id": game.id})
 
 
 @app.route("/games/<string:game_id>", methods=["GET"])
 def get_game_endpoint(game_id):
-    game = get_game(game_id)
+    game = get_last_game_state(game_id)
     if game is None:
         abort(404, description="Resource not found")
 
@@ -39,7 +39,7 @@ def get_game_endpoint(game_id):
 
 @app.route("/games/<string:game_id>/tick", methods=["POST"])
 def tick_game(game_id):
-    game = get_game(game_id)
+    game = get_last_game_state(game_id)
     if game is None:
         abort(404, description="Resource not found")
 

--- a/tests/models/test_actions.py
+++ b/tests/models/test_actions.py
@@ -1,3 +1,6 @@
+from pprint import pprint
+
+
 from catanatron.models.actions import (
     monopoly_possible_actions,
     year_of_plenty_possible_actions,
@@ -5,7 +8,10 @@ from catanatron.models.actions import (
     settlement_possible_actions,
     city_possible_actions,
     robber_possibilities,
+    initial_settlement_possibilites,
+    discard_possibilities,
     ActionType,
+    ActionPrompt,
 )
 from catanatron.models.board import Board
 from catanatron.models.board_initializer import NodeRef, EdgeRef
@@ -19,7 +25,7 @@ def test_playable_actions():
     players = [SimplePlayer(Color.RED), SimplePlayer(Color.BLUE)]
     game = Game(players)
 
-    actions = game.playable_actions(players[0])
+    actions = game.playable_actions(players[0], ActionPrompt.ROLL)
     assert len(actions) == 1
     assert actions[0].action_type == ActionType.ROLL
 
@@ -130,5 +136,17 @@ def test_robber_possibilities():
     # now possibilites increase by 1 b.c. we have to decide to steal from blue or orange
     blue.resource_deck.replenish(1, Resource.WHEAT)
     # TODO: This fails sometimes. Investigate.
-    print(orange, blue, robber_possibilities(red, board, players))
+    pprint(robber_possibilities(red, board, players))
     assert len(robber_possibilities(red, board, players)) == 19
+
+
+def test_initial_placement_possibilities():
+    board = Board()
+    red = SimplePlayer(Color.RED)
+    assert len(initial_settlement_possibilites(red, board, True)) == 54
+
+
+def test_discard_possibilities():
+    player = SimplePlayer(Color.RED)
+    player.resource_deck.replenish(8, Resource.WHEAT)
+    assert len(discard_possibilities(player)) == 70

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -14,7 +14,6 @@ def test_serialization():
             SimplePlayer(Color.ORANGE),
         ]
     )
-    game.play_initial_build_phase()
 
     string = json.dumps(game, cls=GameEncoder)
     result = json.loads(string)

--- a/ui/public/index.html
+++ b/ui/public/index.html
@@ -24,7 +24,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>Catanatron</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>


### PR DESCRIPTION
For machine learning, we need to be able to iterate over all the states of a game. Saving the state and game object to the database on every tick proved to be too slow (increase avg finish time of a game from ~5 secs to ~1 min). So we instead make the refactors necessary to be able to have a function `replay_game` that given a game, can yield all the states of that game. In particular, we had to make the Initial Building Phase to go through the `game.execute(action)` mechanism like everything else.

As such, we created new `ActionType`s that tell the .execute function not to charge for initial roads for example.

Similarly, we change the Discard logic to be just another branching spot in the game logic, so that a tree-exploring algorithm can decide with the same API as the rest of the decisions.

Another item necessary to replay games was to seed the game (to ensure e.g. card-stealing happens in the same way).

We refactored the database layer to allow storing *game_states* as opposed to finalized games, as we first tried to save the state on each tick. This proved to be too slow, but we keep the extra power for now.