### PR TITLE
Minor suggested changes

### DIFF
--- a/catanatron_core/catanatron/models/board.py
+++ b/catanatron_core/catanatron/models/board.py
@@ -104,7 +104,7 @@ class Board:
 
         previous_road_color = self.road_color
         if initial_build_phase:
-            self.connected_components[color].append(set([node_id]))
+            self.connected_components[color].append({node_id})
         else:
             # Maybe cut connected components.
             edges_by_color = defaultdict(list)

--- a/catanatron_core/catanatron/models/board.py
+++ b/catanatron_core/catanatron/models/board.py
@@ -308,10 +308,7 @@ class Board:
             return None
 
     def get_edge_color(self, edge):
-        try:
-            return self.roads[edge]
-        except KeyError:
-            return None
+        return self.roads.get(edge)
 
     def is_enemy_node(self, node_id, color):
         node_color = self.get_node_color(node_id)

--- a/catanatron_gym/catanatron_gym/features.py
+++ b/catanatron_gym/catanatron_gym/features.py
@@ -289,7 +289,8 @@ def reachability_features(game, p0_color, levels=REACHABLE_FEATURES_MAX):
                 base_layer_nodes.add(node_id)
 
         production = count_production(
-            frozenset(owned_or_buildable.intersection(base_layer_nodes)), game.state.board
+            frozenset(owned_or_buildable.intersection(base_layer_nodes)),
+            game.state.board,
         )
         for resource in Resource:
             features[f"P{i}_0_ROAD_REACHABLE_{resource.value}"] = production[resource]

--- a/catanatron_gym/catanatron_gym/features.py
+++ b/catanatron_gym/catanatron_gym/features.py
@@ -282,23 +282,22 @@ def reachability_features(game, p0_color, levels=REACHABLE_FEATURES_MAX):
             + board_buildable
         )
 
-        # Do layer 0
-        zero_nodes = set()
+        # Construct base layer nodes
+        base_layer_nodes = set()
         for component in game.state.board.connected_components[color]:
             for node_id in component:
-                zero_nodes.add(node_id)
+                base_layer_nodes.add(node_id)
 
         production = count_production(
-            frozenset(owned_or_buildable.intersection(zero_nodes)), game.state.board
+            frozenset(owned_or_buildable.intersection(base_layer_nodes)), game.state.board
         )
         for resource in Resource:
             features[f"P{i}_0_ROAD_REACHABLE_{resource.value}"] = production[resource]
 
         # for layers deep:
-        last_layer_nodes = zero_nodes
+        layer_nodes = base_layer_nodes
         for level in range(1, levels):
-            level_nodes = set(last_layer_nodes)
-            for node_id in last_layer_nodes:
+            for node_id in layer_nodes:
                 if game.state.board.is_enemy_node(node_id, color):
                     continue  # not expandable.
 
@@ -307,18 +306,16 @@ def reachability_features(game, p0_color, levels=REACHABLE_FEATURES_MAX):
                     return not game.state.board.is_enemy_road(edge, color)
 
                 expandable = filter(can_follow_edge, STATIC_GRAPH.neighbors(node_id))
-                level_nodes.update(expandable)
+                layer_nodes.update(expandable)
 
             production = count_production(
-                frozenset(owned_or_buildable.intersection(level_nodes)),
+                frozenset(owned_or_buildable.intersection(layer_nodes)),
                 game.state.board,
             )
             for resource in Resource:
                 features[f"P{i}_{level}_ROAD_REACHABLE_{resource.value}"] = production[
                     resource
                 ]
-
-            last_layer_nodes = level_nodes
 
     return features
 


### PR DESCRIPTION
# Summary
Adds minor changes to simplify code.

- In board.py: Initialization for set can use `{}` directly.
- In board.py: Replace `get_edge_color` exception handling with `.get` dictionary method that handles key-value retrieval in similar way without resorting to exceptions.
- In features.py: Is it necessary to create a copy of each layer? I may be reading it incorrectly but it seems we only append to the set at each iteration of the for loop so there's no need for the `level_nodes = set(last_layer_nodes)` line? I may be missing something.
