### PR TITLE
Reduce dependency on state.players on favor of state.colors

### DIFF
--- a/catanatron_core/catanatron/__init__.py
+++ b/catanatron_core/catanatron/__init__.py
@@ -5,4 +5,13 @@ from catanatron import Game, Player, Color, Accumulator
 """
 from catanatron.game import Game, GameAccumulator
 from catanatron.models.player import Player, Color, RandomPlayer
-from catanatron.models.enums import Action, ActionType, WOOD, BRICK, SHEEP, WHEAT, ORE
+from catanatron.models.enums import (
+    Action,
+    ActionType,
+    WOOD,
+    BRICK,
+    SHEEP,
+    WHEAT,
+    ORE,
+    BuildingType,
+)

--- a/catanatron_core/catanatron/game.py
+++ b/catanatron_core/catanatron/game.py
@@ -147,16 +147,16 @@ class Game:
         Returns:
             Union[Color, None]: Might be None if game truncated by TURNS_LIMIT
         """
-        winning_player = None
-        for player in self.state.players:
-            key = player_key(self.state, player.color)
+        result = None
+        for color in self.state.colors:
+            key = player_key(self.state, color)
             if (
                 self.state.player_state[f"{key}_ACTUAL_VICTORY_POINTS"]
                 >= self.vps_to_win
             ):
-                winning_player = player
+                result = color
 
-        return None if winning_player is None else winning_player.color
+        return result
 
     def copy(self) -> "Game":
         """Creates a copy of this Game, that can be modified without

--- a/catanatron_core/catanatron/json.py
+++ b/catanatron_core/catanatron/json.py
@@ -14,8 +14,8 @@ from catanatron.state_functions import get_longest_road_length
 
 def longest_roads_by_player(state):
     result = dict()
-    for player in state.players:
-        result[player.color.value] = get_longest_road_length(state, player.color)
+    for color in state.colors:
+        result[color.value] = get_longest_road_length(state, color)
     return result
 
 
@@ -87,7 +87,7 @@ class GameEncoder(json.JSONEncoder):
                 ),
                 "is_initial_build_phase": obj.state.is_initial_build_phase,
                 "robber_coordinate": obj.state.board.robber_coordinate,
-                "current_color": obj.state.current_player().color,
+                "current_color": obj.state.current_color(),
                 "current_prompt": obj.state.current_prompt,
                 "current_playable_actions": obj.state.playable_actions,
                 "longest_roads_by_player": longest_roads_by_player(obj.state),

--- a/catanatron_core/catanatron/models/actions.py
+++ b/catanatron_core/catanatron/models/actions.py
@@ -41,7 +41,7 @@ from catanatron.state_functions import (
 
 def generate_playable_actions(state) -> List[Action]:
     action_prompt = state.current_prompt
-    color = state.current_player().color
+    color = state.current_color()
 
     if action_prompt == ActionPrompt.BUILD_INITIAL_SETTLEMENT:
         return settlement_possibilities(state, color, True)

--- a/catanatron_core/catanatron/state.py
+++ b/catanatron_core/catanatron/state.py
@@ -130,18 +130,18 @@ class State:
     ):
         if initialize:
             self.players = random.sample(players, len(players))
+            self.colors = tuple([player.color for player in self.players])
             self.board = Board(catan_map or CatanMap(BASE_MAP_TEMPLATE))
             self.discard_limit = discard_limit
 
             # feature-ready dictionary
             self.player_state = dict()
-            for index in range(len(self.players)):
+            for index in range(len(self.colors)):
                 for key, value in PLAYER_INITIAL_STATE.items():
                     self.player_state[f"P{index}_{key}"] = value
             self.color_to_index = {
-                player.color: index for index, player in enumerate(self.players)
+                color: index for index, color in enumerate(self.colors)
             }
-            self.colors = tuple([player.color for player in self.players])
 
             self.resource_freqdeck = starting_resource_bank()
             self.development_listdeck = starting_devcard_bank()
@@ -170,6 +170,10 @@ class State:
     def current_player(self):
         """Helper for accessing Player instance who should decide next"""
         return self.players[self.current_player_index]
+
+    def current_color(self):
+        """Helper for accessing color (player) who should decide next"""
+        return self.colors[self.current_player_index]
 
     def copy(self):
         """Creates a copy of this State class that can be modified without
@@ -281,7 +285,7 @@ def advance_turn(state, direction=1):
 
 
 def next_player_index(state, direction=1):
-    return (state.current_player_index + direction) % len(state.players)
+    return (state.current_player_index + direction) % len(state.colors)
 
 
 def apply_action(state: State, action: Action):

--- a/catanatron_core/catanatron/state_functions.py
+++ b/catanatron_core/catanatron/state_functions.py
@@ -70,17 +70,17 @@ def get_actual_victory_points(state, color):
 
 
 def get_longest_road_color(state):
-    for index in range(len(state.players)):
+    for index in range(len(state.colors)):
         if state.player_state[f"P{index}_HAS_ROAD"]:
-            return state.players[index].color
+            return state.colors[index]
     return None
 
 
 def get_largest_army(state):
-    for index in range(len(state.players)):
+    for index in range(len(state.colors)):
         if state.player_state[f"P{index}_HAS_ARMY"]:
             return (
-                state.players[index].color,
+                state.colors[index],
                 state.player_state[f"P{index}_PLAYED_KNIGHT"],
             )
     return None, None

--- a/catanatron_experimental/catanatron_experimental/benchmarks/benchmark_create_sample_vector.py
+++ b/catanatron_experimental/catanatron_experimental/benchmarks/benchmark_create_sample_vector.py
@@ -21,28 +21,28 @@ game.play()
 
 NUMBER = 1000  # usually a game has around 300 turns and 1000 ticks
 result = timeit.timeit(
-    "create_sample_vector(game, game.state.players[0].color)",
+    "create_sample_vector(game, game.state.colors[0])",
     setup=setup,
     number=NUMBER,
 )
 print("create_sample_vector\t", result / NUMBER, "secs")
 
 result = timeit.timeit(
-    "expansion_features(game, game.state.players[0].color)",
+    "expansion_features(game, game.state.colors[0])",
     setup=setup,
     number=NUMBER,
 )
 print("expansion_features\t", result / NUMBER, "secs")
 
 result = timeit.timeit(
-    "reachability_features(game, game.state.players[0].color)",
+    "reachability_features(game, game.state.colors[0])",
     setup=setup,
     number=NUMBER,
 )
 print("reachability_features\t", result / NUMBER, "secs")
 
 result = timeit.timeit(
-    "graph_features(game, game.state.players[0].color)",
+    "graph_features(game, game.state.colors[0])",
     setup=setup,
     number=NUMBER,
 )
@@ -50,7 +50,7 @@ print("graph_features\t\t", result / NUMBER, "secs")
 
 
 result = timeit.timeit(
-    "tile_features(game, game.state.players[0].color)",
+    "tile_features(game, game.state.colors[0])",
     setup=setup,
     number=NUMBER,
 )

--- a/catanatron_experimental/catanatron_experimental/benchmarks/benchmark_game_copy.py
+++ b/catanatron_experimental/catanatron_experimental/benchmarks/benchmark_game_copy.py
@@ -31,8 +31,6 @@ print(result / NUMBER, "secs; game.copy()")
 # Next step
 result = timeit.timeit(
     """
-players = game.state.players.copy()
-
 board = dict()
 board['map'] = game.state.board.map  # for caching speedups
 board['buildings'] = game.state.board.buildings.copy()
@@ -40,7 +38,7 @@ board['roads'] = game.state.board.roads.copy()
 board['connected_components'] = game.state.board.connected_components.copy()
 
 state_copy = dict()
-state_copy['players'] = players
+state_copy['colors'] = game.state.colors.copy()
 state_copy['board'] = board
 state_copy['actions'] = game.state.actions.copy()
 state_copy['resource_freqdeck'] = game.state.resource_freqdeck.copy()

--- a/catanatron_experimental/catanatron_experimental/cli/accumulators.py
+++ b/catanatron_experimental/catanatron_experimental/cli/accumulators.py
@@ -127,9 +127,9 @@ class StatisticsAccumulator(GameAccumulator):
         self.durations.append(duration)
         self.games.append(game)
 
-        for player in game.state.players:
-            points = get_actual_victory_points(game.state, player.color)
-            self.results_by_player[player.color].append(points)
+        for color in game.state.colors:
+            points = get_actual_victory_points(game.state, color)
+            self.results_by_player[color].append(points)
 
     def get_avg_ticks(self):
         return sum(self.ticks) / len(self.ticks)

--- a/catanatron_experimental/catanatron_experimental/data_logger.py
+++ b/catanatron_experimental/catanatron_experimental/data_logger.py
@@ -30,13 +30,13 @@ class DataLogger:
         self.log_lines = []
 
     def consume(self, game, mcts_labels):
-        for player in game.state.players:
-            sample = create_sample_vector(game, player.color)
+        for color in game.state.colors:
+            sample = create_sample_vector(game, color)
             flattened_board_tensor = tf.reshape(
-                create_board_tensor(game, player.color),
+                create_board_tensor(game, color),
                 (WIDTH * HEIGHT * CHANNELS,),
             ).numpy()
-            label = mcts_labels.get(player.color, 0)
+            label = mcts_labels.get(color, 0)
 
             self.samples.append(sample)
             self.board_tensors.append(flattened_board_tensor)

--- a/catanatron_experimental/catanatron_experimental/machine_learning/players/minimax.py
+++ b/catanatron_experimental/catanatron_experimental/machine_learning/players/minimax.py
@@ -290,7 +290,7 @@ class AlphaBetaPlayer(Player):
             node.expected_value = value
             return None, value
 
-        maximizingPlayer = game.state.current_player().color == self.color
+        maximizingPlayer = game.state.current_color() == self.color
         actions = self.get_actions(game)  # list of actions.
         action_outcomes = expand_spectrum(game, actions)  # action => (game, proba)[]
 
@@ -303,7 +303,7 @@ class AlphaBetaPlayer(Player):
                 expected_value = 0
                 for j, (outcome, proba) in enumerate(outcomes):
                     out_node = DebugStateNode(
-                        f"{node.label} {i} {j}", outcome.state.current_player().color
+                        f"{node.label} {i} {j}", outcome.state.current_color()
                     )
 
                     result = self.alphabeta(
@@ -336,7 +336,7 @@ class AlphaBetaPlayer(Player):
                 expected_value = 0
                 for j, (outcome, proba) in enumerate(outcomes):
                     out_node = DebugStateNode(
-                        f"{node.label} {i} {j}", outcome.state.current_player().color
+                        f"{node.label} {i} {j}", outcome.state.current_color()
                     )
 
                     result = self.alphabeta(
@@ -414,7 +414,7 @@ def render_debug_tree(node):
 
 
 def list_prunned_actions(game):
-    current_color = game.state.current_player().color
+    current_color = game.state.current_color()
     playable_actions = game.state.playable_actions
     actions = playable_actions.copy()
     types = set(map(lambda a: a.action_type, playable_actions))
@@ -450,13 +450,13 @@ def list_prunned_actions(game):
 
 def prune_robber_actions(current_color, game, actions):
     """Eliminate all but the most impactful tile"""
-    enemy = next(filter(lambda p: p.color != current_color, game.state.players))
+    enemy_color = next(filter(lambda c: c != current_color, game.state.colors))
     enemy_owned_tiles = set()
     for node_id in get_player_buildings(
-        game.state, enemy.color, BuildingType.SETTLEMENT
+        game.state, enemy_color, BuildingType.SETTLEMENT
     ):
         enemy_owned_tiles.update(game.state.board.map.adjacent_tiles[node_id])
-    for node_id in get_player_buildings(game.state, enemy.color, BuildingType.CITY):
+    for node_id in get_player_buildings(game.state, enemy_color, BuildingType.CITY):
         enemy_owned_tiles.update(game.state.board.map.adjacent_tiles[node_id])
 
     robber_moves = set(

--- a/catanatron_gym/catanatron_gym/envs/catanatron_env.py
+++ b/catanatron_gym/catanatron_gym/envs/catanatron_env.py
@@ -163,7 +163,7 @@ class CatanatronEnv(gym.Env):
     def _advance_until_p0_decision(self):
         while (
             self.game.winning_color() is None
-            and self.game.state.current_player().color != self.p0.color
+            and self.game.state.current_color() != self.p0.color
         ):
             self.game.play_tick()  # will play bot
 

--- a/catanatron_gym/catanatron_gym/features.py
+++ b/catanatron_gym/catanatron_gym/features.py
@@ -250,14 +250,14 @@ def get_node_production(board, node_id, resource):
 
 def get_player_expandable_nodes(game: Game, color: Color):
     node_sets = game.state.board.find_connected_components(color)
-    enemies = [enemy for enemy in game.state.players if enemy.color != color]
+    enemy_colors = [enemy_color for enemy_color in game.state.colors if enemy_color != color]
     enemy_node_ids = set()
-    for enemy in enemies:
+    for enemy_color in enemy_colors:
         enemy_node_ids.update(
-            get_player_buildings(game.state, enemy.color, BuildingType.SETTLEMENT)
+            get_player_buildings(game.state, enemy_color, BuildingType.SETTLEMENT)
         )
         enemy_node_ids.update(
-            get_player_buildings(game.state, enemy.color, BuildingType.CITY)
+            get_player_buildings(game.state, enemy_color, BuildingType.CITY)
         )
 
     expandable_node_ids = [

--- a/catanatron_gym/catanatron_gym/features.py
+++ b/catanatron_gym/catanatron_gym/features.py
@@ -250,7 +250,9 @@ def get_node_production(board, node_id, resource):
 
 def get_player_expandable_nodes(game: Game, color: Color):
     node_sets = game.state.board.find_connected_components(color)
-    enemy_colors = [enemy_color for enemy_color in game.state.colors if enemy_color != color]
+    enemy_colors = [
+        enemy_color for enemy_color in game.state.colors if enemy_color != color
+    ]
     enemy_node_ids = set()
     for enemy_color in enemy_colors:
         enemy_node_ids.update(
@@ -272,45 +274,62 @@ def get_player_expandable_nodes(game: Game, color: Color):
 REACHABLE_FEATURES_MAX = 3  # exclusive
 
 
+def get_zero_nodes(game, color):
+    zero_nodes = set()
+    for component in game.state.board.connected_components[color]:
+        for node_id in component:
+            zero_nodes.add(node_id)
+    return zero_nodes
+
+
+def iter_level_nodes(game, color, levels, zero_nodes):
+    """Yields (level, level_nodes) tuples"""
+    last_layer_nodes = zero_nodes
+    for level in range(1, levels):
+        level_nodes = set(last_layer_nodes)
+        for node_id in last_layer_nodes:
+            if game.state.board.is_enemy_node(node_id, color):
+                continue  # not expandable.
+
+            def can_follow_edge(neighbor_id):
+                edge = (node_id, neighbor_id)
+                return not game.state.board.is_enemy_road(edge, color)
+
+            # here we can assume node is empty or owned
+            expandable = filter(can_follow_edge, STATIC_GRAPH.neighbors(node_id))
+            level_nodes.update(expandable)
+
+        yield level, level_nodes
+
+        last_layer_nodes = level_nodes
+
+
+def get_owned_or_buildable(game, color, board_buildable):
+    return frozenset(
+        get_player_buildings(game.state, color, BuildingType.SETTLEMENT)
+        + get_player_buildings(game.state, color, BuildingType.CITY)
+        + board_buildable
+    )
+
+
 def reachability_features(game: Game, p0_color: Color, levels=REACHABLE_FEATURES_MAX):
     features = {}
 
     board_buildable = game.state.board.buildable_node_ids(p0_color, True)
     for i, color in iter_players(game.state.colors, p0_color):
-        owned_or_buildable = frozenset(
-            get_player_buildings(game.state, color, BuildingType.SETTLEMENT)
-            + get_player_buildings(game.state, color, BuildingType.CITY)
-            + board_buildable
-        )
+        owned_or_buildable = get_owned_or_buildable(game, color, board_buildable)
 
-        # Do layer 0
-        base_layer_nodes = set()
-        for component in game.state.board.connected_components[color]:
-            for node_id in component:
-                base_layer_nodes.add(node_id)
-
+        # do layer 0
+        zero_nodes = get_zero_nodes(game, color)
         production = count_production(
-            frozenset(owned_or_buildable.intersection(base_layer_nodes)),
+            frozenset(owned_or_buildable.intersection(zero_nodes)),
             game.state.board,
         )
         for resource in RESOURCES:
             features[f"P{i}_0_ROAD_REACHABLE_{resource}"] = production[resource]
 
-        # for layers deep:
-        last_layer_nodes = base_layer_nodes
-        for level in range(1, levels):
-            level_nodes = set(last_layer_nodes)
-            for node_id in last_layer_nodes:
-                if game.state.board.is_enemy_node(node_id, color):
-                    continue  # not expandable.
-
-                def can_follow_edge(neighbor_id):
-                    edge = (node_id, neighbor_id)
-                    return not game.state.board.is_enemy_road(edge, color)
-
-                expandable = filter(can_follow_edge, STATIC_GRAPH.neighbors(node_id))
-                level_nodes.update(expandable)
-
+        # do rest of layers
+        for (level, level_nodes) in iter_level_nodes(game, color, levels, zero_nodes):
             production = count_production(
                 frozenset(owned_or_buildable.intersection(level_nodes)),
                 game.state.board,
@@ -319,8 +338,6 @@ def reachability_features(game: Game, p0_color: Color, levels=REACHABLE_FEATURES
                 features[f"P{i}_{level}_ROAD_REACHABLE_{resource}"] = production[
                     resource
                 ]
-
-            last_layer_nodes = level_nodes
 
     return features
 

--- a/catanatron_server/catanatron_server/api.py
+++ b/catanatron_server/catanatron_server/api.py
@@ -87,7 +87,7 @@ def post_action_endpoint(game_id):
 #     if game is None:
 #         abort(404, description="Resource not found")
 
-#     return create_sample(game, game.state.players[player_index].color)
+#     return create_sample(game, game.state.colors[player_index])
 
 
 # @app.route("/games/<string:game_id>/value-function", methods=["GET"])
@@ -101,15 +101,15 @@ def post_action_endpoint(game_id):
 #     feature_ordering = get_feature_ordering()
 #     indices = [feature_ordering.index(f) for f in NUMERIC_FEATURES]
 #     data = {}
-#     for player in game.state.players:
-#         sample = create_sample_vector(game, player.color)
+#     for color in game.state.colors:
+#         sample = create_sample_vector(game, color)
 #         # scores = model.call(tf.convert_to_tensor([sample]))
 
-#         inputs1 = [create_board_tensor(game, player.color)]
+#         inputs1 = [create_board_tensor(game, color)]
 #         inputs2 = [[float(sample[i]) for i in indices]]
 #         scores2 = model2.call(
 #             [tf.convert_to_tensor(inputs1), tf.convert_to_tensor(inputs2)]
 #         )
-#         data[player.color.value] = float(scores2.numpy()[0][0])
+#         data[color.value] = float(scores2.numpy()[0][0])
 
 #     return data

--- a/tests/integration_tests/test_replay.py
+++ b/tests/integration_tests/test_replay.py
@@ -63,10 +63,10 @@ def test_execute_action_on_copies_doesnt_conflict():
         SimplePlayer(Color.ORANGE),
     ]
     game = Game(players)
-    p0 = game.state.players[0]
-    game.execute(Action(p0.color, ActionType.BUILD_SETTLEMENT, 0))
+    p0_color = game.state.colors[0]
+    game.execute(Action(p0_color, ActionType.BUILD_SETTLEMENT, 0))
 
-    action = Action(p0.color, ActionType.BUILD_ROAD, (0, 1))
+    action = Action(p0_color, ActionType.BUILD_ROAD, (0, 1))
 
     game_copy = game.copy()
     game_copy.execute(action)

--- a/tests/models/test_actions.py
+++ b/tests/models/test_actions.py
@@ -141,7 +141,7 @@ def test_building_settlement_gives_vp():
     players = [SimplePlayer(Color.RED), SimplePlayer(Color.BLUE)]
     state = State(players)
 
-    build_settlement(state, state.players[0].color, 0, True)
+    build_settlement(state, state.colors[0], 0, True)
     assert state.player_state["P0_VICTORY_POINTS"] == 1
     assert state.player_state["P0_ACTUAL_VICTORY_POINTS"] == 1
 
@@ -150,10 +150,10 @@ def test_building_city_gives_vp():
     players = [SimplePlayer(Color.RED), SimplePlayer(Color.BLUE)]
     state = State(players)
 
-    build_settlement(state, state.players[0].color, 0, True)
-    player_deck_replenish(state, state.players[0].color, WHEAT, 2)
-    player_deck_replenish(state, state.players[0].color, ORE, 2)
-    build_city(state, state.players[0].color, 0)
+    build_settlement(state, state.colors[0], 0, True)
+    player_deck_replenish(state, state.colors[0], WHEAT, 2)
+    player_deck_replenish(state, state.colors[0], ORE, 2)
+    build_city(state, state.colors[0], 0)
     assert state.player_state["P0_VICTORY_POINTS"] == 2
     assert state.player_state["P0_ACTUAL_VICTORY_POINTS"] == 2
 

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -68,7 +68,7 @@ def test_initial_build_phase():
     )
     assert (
         game.state.current_prompt == ActionPrompt.PLAY_TURN
-        and game.state.current_player().color == p0_color
+        and game.state.current_color() == p0_color
     )
 
     assert game.state.player_state["P0_ACTUAL_VICTORY_POINTS"] == 2
@@ -185,19 +185,19 @@ def test_end_turn_goes_to_next_player(fake_roll_dice):
     p1_color = game.state.colors[1]
     assert (
         game.state.current_prompt == ActionPrompt.PLAY_TURN
-        and game.state.current_player().color == p0_color
+        and game.state.current_color() == p0_color
     )
     assert game.state.playable_actions == [Action(p0_color, ActionType.ROLL, None)]
 
     game.execute(Action(p0_color, ActionType.ROLL, None))
     assert game.state.current_prompt == ActionPrompt.PLAY_TURN
-    assert game.state.current_player().color == p0_color
+    assert game.state.current_color() == p0_color
     assert player_has_rolled(game.state, p0_color)
     assert Action(p0_color, ActionType.END_TURN, None) in game.state.playable_actions
 
     game.execute(Action(p0_color, ActionType.END_TURN, None))
     assert game.state.current_prompt == ActionPrompt.PLAY_TURN
-    assert game.state.current_player().color == p1_color
+    assert game.state.current_color() == p1_color
     assert not player_has_rolled(game.state, p0_color)
     assert not player_has_rolled(game.state, p1_color)
     assert game.state.playable_actions == [Action(p1_color, ActionType.ROLL, None)]

--- a/tests/test_machine_learning.py
+++ b/tests/test_machine_learning.py
@@ -71,7 +71,7 @@ def test_port_distance_features():
         SimplePlayer(Color.ORANGE),
     ]
     game = Game(players)
-    color = game.state.players[0].color
+    color = game.state.colors[0]
     game.execute(Action(color, ActionType.BUILD_SETTLEMENT, 3))
     game.execute(Action(color, ActionType.BUILD_ROAD, (2, 3)))
 
@@ -112,7 +112,7 @@ def test_expansion_features():
         SimplePlayer(Color.ORANGE),
     ]
     game = Game(players)
-    color = game.state.players[0].color
+    color = game.state.colors[0]
     game.execute(Action(color, ActionType.BUILD_SETTLEMENT, 3))
     game.execute(Action(color, ActionType.BUILD_ROAD, (2, 3)))
 
@@ -141,7 +141,7 @@ def test_reachability_features():
     random.sample(players, len(players))
     catan_map = CatanMap(BASE_MAP_TEMPLATE)
     game = Game(players, seed=123, catan_map=catan_map)
-    p0_color = game.state.players[0].color
+    p0_color = game.state.colors[0]
 
     game.execute(Action(p0_color, ActionType.BUILD_SETTLEMENT, 5))
     features = reachability_features(game, p0_color)
@@ -177,7 +177,7 @@ def test_reachability_features():
     )
 
     # Test enemy making building removes buildability
-    p1_color = game.state.players[1].color
+    p1_color = game.state.colors[1]
     game.execute(Action(p1_color, ActionType.BUILD_SETTLEMENT, 1))
     features = reachability_features(game, p0_color)
     assert features["P0_1_ROAD_REACHABLE_ORE"] == number_probability(8)
@@ -236,7 +236,7 @@ def test_graph_features():
         SimplePlayer(Color.ORANGE),
     ]
     game = Game(players)
-    p0_color = game.state.players[0].color
+    p0_color = game.state.colors[0]
     game.execute(Action(p0_color, ActionType.BUILD_SETTLEMENT, 3))
     game.execute(Action(p0_color, ActionType.BUILD_ROAD, (2, 3)))
 
@@ -261,7 +261,7 @@ def test_graph_features_in_mini():
         SimplePlayer(Color.BLUE),
     ]
     game = Game(players, catan_map=CatanMap(MINI_MAP_TEMPLATE))
-    p0_color = game.state.players[0].color
+    p0_color = game.state.colors[0]
     game.execute(Action(p0_color, ActionType.BUILD_SETTLEMENT, 3))
     game.execute(Action(p0_color, ActionType.BUILD_ROAD, (2, 3)))
 
@@ -329,10 +329,10 @@ def test_init_tile_map():
 def test_create_board_tensor():
     players = [SimplePlayer(Color.RED), SimplePlayer(Color.BLUE)]
     game = Game(players)
-    p0 = game.state.players[0]
+    p0_color = game.state.colors[0]
 
     # assert starts with no settlement/cities
-    tensor = create_board_tensor(game, p0.color)
+    tensor = create_board_tensor(game, p0_color)
     assert tensor.shape == (21, 11, 20 - 4)
     assert tensor[0][0][0] == 0
     assert tensor[10][6][0] == 0
@@ -340,15 +340,15 @@ def test_create_board_tensor():
 
     # assert settlement and road mark 1s correspondingly
     build_initial_placements(game, p0_actions=[3, (3, 4), 37, (14, 37)])
-    tensor = create_board_tensor(game, p0.color)
+    tensor = create_board_tensor(game, p0_color)
     assert tensor[10][6][0] == 1
     assert tensor[9][6][1] == 1
 
-    player_deck_replenish(game.state, p0.color, WHEAT, 2)
-    player_deck_replenish(game.state, p0.color, ORE, 3)
+    player_deck_replenish(game.state, p0_color, WHEAT, 2)
+    player_deck_replenish(game.state, p0_color, ORE, 3)
     advance_to_play_turn(game)
-    game.execute(Action(p0.color, ActionType.BUILD_CITY, 3))
-    tensor = create_board_tensor(game, p0.color)
+    game.execute(Action(p0_color, ActionType.BUILD_CITY, 3))
+    tensor = create_board_tensor(game, p0_color)
     assert tensor[10][6][0] == 2
     assert tensor[9][6][1] == 1
 
@@ -488,20 +488,20 @@ def test_iter_players():
 
     # Test the firsts look good.
     for i in range(4):
-        j, c = iter_players(tuple(game.state.colors), game.state.players[i].color)[0]
-        assert c == game.state.players[i].color
+        j, c = iter_players(tuple(game.state.colors), game.state.colors[i])[0]
+        assert c == game.state.colors[i]
 
-    # Test a specific case (p0=game.state.players[0])
-    iterator = iter_players(tuple(game.state.colors), game.state.players[0].color)
+    # Test a specific case (p0=game.state.colors[0])
+    iterator = iter_players(tuple(game.state.colors), game.state.colors[0])
     i, c = iterator[0]
     assert i == 0
-    assert c == game.state.players[0].color
+    assert c == game.state.colors[0]
     i, c = iterator[1]
     assert i == 1
-    assert c == game.state.players[1].color
+    assert c == game.state.colors[1]
     i, c = iterator[2]
     assert i == 2
-    assert c == game.state.players[2].color
+    assert c == game.state.colors[2]
     i, c = iterator[3]
     assert i == 3
-    assert c == game.state.players[3].color
+    assert c == game.state.colors[3]

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -186,9 +186,9 @@ def test_sequence():
     ]
     state = State(players)
 
-    p0 = state.players[0]
+    p0_color = state.colors[0]
     assert state.current_prompt == ActionPrompt.BUILD_INITIAL_SETTLEMENT
-    assert Action(p0.color, ActionType.BUILD_SETTLEMENT, 0) in state.playable_actions
-    assert Action(p0.color, ActionType.BUILD_SETTLEMENT, 50) in state.playable_actions
+    assert Action(p0_color, ActionType.BUILD_SETTLEMENT, 0) in state.playable_actions
+    assert Action(p0_color, ActionType.BUILD_SETTLEMENT, 50) in state.playable_actions
 
     apply_action(state, state.playable_actions[0])

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -7,8 +7,8 @@ def build_initial_placements(
     p0_actions=[0, (0, 1), 2, (1, 2)],
     p1_actions=[24, (24, 25), 26, (25, 26)],
 ):
-    p0_color = game.state.players[0].color
-    p1_color = game.state.players[1].color
+    p0_color = game.state.colors[0]
+    p1_color = game.state.colors[1]
     game.execute(Action(p0_color, ActionType.BUILD_SETTLEMENT, p0_actions[0]))
     game.execute(Action(p0_color, ActionType.BUILD_ROAD, p0_actions[1]))
 
@@ -22,7 +22,7 @@ def build_initial_placements(
 
 
 def advance_to_play_turn(game):
-    game.execute(Action(game.state.current_player().color, ActionType.ROLL, None))
+    game.execute(Action(game.state.current_color(), ActionType.ROLL, None))
     while game.state.playable_actions[0].action_type in [
         ActionType.DISCARD,
         ActionType.MOVE_ROBBER,
@@ -31,4 +31,4 @@ def advance_to_play_turn(game):
 
 
 def end_turn(game):
-    game.execute(Action(game.state.current_player().color, ActionType.END_TURN, None))
+    game.execute(Action(game.state.current_color(), ActionType.END_TURN, None))


### PR DESCRIPTION
Further separation of state with player decision making logic.

This should make easier to be able to serialize/de-serialize games without having to serialize the player classes. I am thinking just storing a JSON of that player-class-independent state, and some importlib-enabled references to the player classes per color would work? This way Python processes could import the players (if in path) and there would be no need to serialize player classes.

What about players that have internal state during the game(?). Lets not support them for now, if anyone wants local state and serialization, they would have to use a global state instead...