### PR TITLE
Fixes #160: Add pips to tiles

### DIFF
--- a/ui/src/pages/Board.scss
+++ b/ui/src/pages/Board.scss
@@ -56,8 +56,8 @@
 
 .MuiPaper-elevation3.robber {
   background: #6b6b6b;
-
   position: absolute;
+  font-size: 100%;
 }
 
 // ===== Tiles

--- a/ui/src/pages/Tile.js
+++ b/ui/src/pages/Tile.js
@@ -2,6 +2,7 @@ import React from "react";
 import cn from "classnames";
 import Paper from "@material-ui/core/Paper";
 
+import "./Tile.scss";
 import brickTile from "../assets/tile_brick.svg";
 import desertTile from "../assets/tile_desert.svg";
 import grainTile from "../assets/tile_wheat.svg";
@@ -14,8 +15,11 @@ export function NumberToken({ className, children, style, size }) {
   return (
     <Paper
       elevation={3}
-      className={cn("number-token", className)}
-      style={{ ...style, width: size, height: size, "text-align": "center" }}
+      className={cn("number-token", "hexagon", className)}
+      style={{
+        "--base-size": `${size}px`, // this var can be overrided via `style` prop
+        ...style,
+      }}
     >
       {children}
     </Paper>

--- a/ui/src/pages/Tile.js
+++ b/ui/src/pages/Tile.js
@@ -26,21 +26,21 @@ const numberToPips = (number) => {
   switch(number) {
     case 2:
     case 12:
-      return 1;
+      return '•';
     case 3:
     case 11:
-      return 2;
+      return '••';
     case 4:
     case 10:
-      return 3;
+      return '•••';
     case 5:
     case 9:
-      return 4;
+      return '••••';
     case 6:
     case 8:
-      return 5;
+      return '•••••';
     default:
-      return 0;  
+      return '';  
   }
 };
 

--- a/ui/src/pages/Tile.js
+++ b/ui/src/pages/Tile.js
@@ -22,6 +22,28 @@ export function NumberToken({ className, children, style, size }) {
   );
 }
 
+const numberToPips = (number) => {
+  switch(number) {
+    case 2:
+    case 12:
+      return 1;
+    case 3:
+    case 11:
+      return 2;
+    case 4:
+    case 10:
+      return 3;
+    case 5:
+    case 9:
+      return 4;
+    case 6:
+    case 8:
+      return 5;
+    default:
+      return 0;  
+  }
+};
+
 export default function Tile({ center, coordinate, tile, size }) {
   const w = SQRT3 * size;
   const h = 2 * size;
@@ -31,7 +53,7 @@ export default function Tile({ center, coordinate, tile, size }) {
   let contents;
   let resourceTile;
   if (tile.type === "RESOURCE_TILE") {
-    contents = <NumberToken size={size}>{tile.number}</NumberToken>;
+    contents = <NumberToken size={size}>{tile.number}<br/>{numberToPips(tile.number)}</NumberToken>;
     resourceTile = {
       BRICK: brickTile,
       SHEEP: woolTile,

--- a/ui/src/pages/Tile.js
+++ b/ui/src/pages/Tile.js
@@ -59,8 +59,8 @@ export default function Tile({ center, coordinate, tile, size }) {
   if (tile.type === "RESOURCE_TILE") {
     contents = (
       <NumberToken size={size}>
-        <span>{tile.number}</span>
-        <span class="pips">{numberToPips(tile.number)}</span>
+        <div>{tile.number}</div>
+        <div class="pips">{numberToPips(tile.number)}</div>
       </NumberToken>
     );
     resourceTile = {

--- a/ui/src/pages/Tile.js
+++ b/ui/src/pages/Tile.js
@@ -59,11 +59,8 @@ export default function Tile({ center, coordinate, tile, size }) {
   if (tile.type === "RESOURCE_TILE") {
     contents = (
       <NumberToken size={size}>
-        <span>
-          {tile.number}
-          <br />
-          {numberToPips(tile.number)}
-        </span>
+        <span>{tile.number}</span>
+        <span class="pips">{numberToPips(tile.number)}</span>
       </NumberToken>
     );
     resourceTile = {

--- a/ui/src/pages/Tile.js
+++ b/ui/src/pages/Tile.js
@@ -15,7 +15,7 @@ export function NumberToken({ className, children, style, size }) {
   return (
     <Paper
       elevation={3}
-      className={cn("number-token", "hexagon", className)}
+      className={cn("number-token", className)}
       style={{
         "--base-size": `${size}px`, // this var can be overrided via `style` prop
         ...style,
@@ -59,9 +59,11 @@ export default function Tile({ center, coordinate, tile, size }) {
   if (tile.type === "RESOURCE_TILE") {
     contents = (
       <NumberToken size={size}>
-        {tile.number}
-        <br />
-        {numberToPips(tile.number)}
+        <span>
+          {tile.number}
+          <br />
+          {numberToPips(tile.number)}
+        </span>
       </NumberToken>
     );
     resourceTile = {

--- a/ui/src/pages/Tile.scss
+++ b/ui/src/pages/Tile.scss
@@ -1,10 +1,23 @@
-.hexagon {
-    --hex-height-factor: 1.1547; // make the height and width look even for hexagon
-    --scale-factor: 0.6;
+@import "../variables.scss";
+
+.number-token {
+    --scale-factor: 0.65;
     width: calc(var(--base-size) * var(--scale-factor));
-    height: calc(var(--base-size) * var(--scale-factor) * var(--hex-height-factor));
-    clip-path: polygon(0% 25%, 0% 75%, 50% 100%, 100% 75%, 100% 25%, 50% 0%);
+    height: calc(var(--base-size) * var(--scale-factor));
     text-align: center;
-    font-size: 95%;
-    line-height: .8em;
+
+    span {
+            line-height: .8;
+            top: 0;
+            bottom: 0;
+            margin: auto;
+    }
+    @media(max-width: $sm-breakpoint) {
+        .number-token {
+            font-size: 75%;
+        }
+    }
+
 }
+
+

--- a/ui/src/pages/Tile.scss
+++ b/ui/src/pages/Tile.scss
@@ -2,19 +2,19 @@
 
 .number-token {
     --scale-factor: 0.65;
-    width: calc(var(--base-size) * var(--scale-factor));
-    height: calc(var(--base-size) * var(--scale-factor));
+    --base-font-size: 100%;
+    height: min-content;
+    width: min-content;
     text-align: center;
+    padding: 5px;
+    line-height: .8rem;
 
-    span {
-            line-height: .8;
-            top: 0;
-            bottom: 0;
-            margin: auto;
+    .pips {
+        font-size: calc(var(--base-font-size) * 60);
     }
     @media(max-width: $sm-breakpoint) {
         .number-token {
-            font-size: 75%;
+            --base-font-size: 75%;
         }
     }
 

--- a/ui/src/pages/Tile.scss
+++ b/ui/src/pages/Tile.scss
@@ -3,21 +3,22 @@
 .number-token {
     --scale-factor: 0.65;
     --base-font-size: 100%;
-    height: min-content;
-    width: min-content;
+    height: 4ch;
+    width: 4ch;
     text-align: center;
     padding: 5px;
     line-height: .8rem;
-
+    position: relative;
+    display: flex;
+    flex-direction: column;
     .pips {
-        font-size: calc(var(--base-font-size) * 60);
+        font-size: calc(var(--base-font-size) * 60%);
     }
-    @media(max-width: $sm-breakpoint) {
-        .number-token {
-            --base-font-size: 75%;
-        }
-    }
-
 }
 
+@media(max-width: $sm-breakpoint) {
+    .number-token {
+        --base-font-size: 75%;
+    }
+}
 

--- a/ui/src/pages/Tile.scss
+++ b/ui/src/pages/Tile.scss
@@ -1,0 +1,10 @@
+.hexagon {
+    --hex-height-factor: 1.1547; // make the height and width look even for hexagon
+    --scale-factor: 0.6;
+    width: calc(var(--base-size) * var(--scale-factor));
+    height: calc(var(--base-size) * var(--scale-factor) * var(--hex-height-factor));
+    clip-path: polygon(0% 25%, 0% 75%, 50% 100%, 100% 75%, 100% 25%, 50% 0%);
+    text-align: center;
+    font-size: 95%;
+    line-height: .8em;
+}


### PR DESCRIPTION
Adds pips to the relevant tiles using the '•' character, and a helper to map from the Number on the tile to the number of pips.

Opening this for review but haven't really tested it locally yet.