### PR TITLE
Ensure PyPi versions work

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -57,7 +57,7 @@ jobs:
         run: |
           coveralls --service=github
 
-  build-pypi:
+  build-gym:
     runs-on: ubuntu-latest
 
     steps:
@@ -68,14 +68,13 @@ jobs:
           python-version: 3.8
       - name: Install dependencies
         run: |
-          pip install -e catanatron_core
           pip install -e catanatron_gym
-      - name: Run sample catanatron-play
-        run: |
-          catanatron-play --players=R,W,F,AB:2 --num=2
       - name: Test with pytest
         run: |
           pytest tests/
+      - name: Inline test
+        run: |
+          python -c "import gym; env = gym.make('catanatron_gym:catanatron-v0')"
 
   build-ui:
     runs-on: ubuntu-latest

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -68,6 +68,7 @@ jobs:
           python-version: 3.8
       - name: Install dependencies
         run: |
+          pip install -e catanatron_core
           pip install -e catanatron_gym
       - name: Inline test
         run: |

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -69,9 +69,6 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -e catanatron_gym
-      - name: Test with pytest
-        run: |
-          pytest tests/
       - name: Inline test
         run: |
           python -c "import gym; env = gym.make('catanatron_gym:catanatron-v0')"

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -57,6 +57,26 @@ jobs:
         run: |
           coveralls --service=github
 
+  build-pypi:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Install dependencies
+        run: |
+          pip install -e catanatron_core
+          pip install -e catanatron_gym
+      - name: Run sample catanatron-play
+        run: |
+          catanatron-play --players=R,W,F,AB:2 --num=2
+      - name: Test with pytest
+        run: |
+          pytest tests/
+
   build-ui:
     runs-on: ubuntu-latest
 

--- a/catanatron_core/setup.py
+++ b/catanatron_core/setup.py
@@ -8,7 +8,7 @@ with open(readme_path, "r") as fh:
 
 setuptools.setup(
     name="catanatron",
-    version="3.2.0",
+    version="3.2.1",
     author="Bryan Collazo",
     author_email="bcollazo2010@gmail.com",
     description="Fast Settlers of Catan Python Implementation",

--- a/catanatron_gym/setup.py
+++ b/catanatron_gym/setup.py
@@ -22,5 +22,5 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     python_requires=">=3.6",
-    install_requires=["catanatron", "gym", "numpy"],
+    install_requires=["catanatron", "gym==0.21.0", "numpy"],
 )

--- a/catanatron_gym/setup.py
+++ b/catanatron_gym/setup.py
@@ -8,7 +8,7 @@ with open(readme_path, "r") as fh:
 
 setuptools.setup(
     name="catanatron_gym",
-    version="3.2.0",
+    version="3.2.1",
     author="Bryan Collazo",
     author_email="bcollazo2010@gmail.com",
     description="Open AI Gym to play 1v1 Catan against a random bot",


### PR DESCRIPTION
It seems Gym 0.25 now uses "render_modes" instead of "render.modes" which was yielding this error: https://github.com/bcollazo/catanatron/discussions/55#discussioncomment-3163715.

Quick fix here is to add a CI check that ensures at least standalone `catanatron-gym` is installable and usable, and to lock the required gym to `gym==0.21.0`.