### PR TITLE
Fix DOCS build

### DIFF
--- a/catanatron_core/catanatron/models/enums.py
+++ b/catanatron_core/catanatron/models/enums.py
@@ -102,7 +102,7 @@ We use this class to represent both the _intent_ of say "moving a
 robber to Tile (0,0,0) and stealing from Blue" as well as
 the final result of such a move. In moves like these where the intent
 is not enough to be used to reproduce the game identically,
-we use `None`s in the "value" container as placeholders 
+we use "None"s in the "value" container as placeholders 
 for that information needed for fully reproducing a game.
 (e.g. card stolen, dev card bought, etc...)
 

--- a/catanatron_gym/catanatron_gym/features.py
+++ b/catanatron_gym/catanatron_gym/features.py
@@ -290,7 +290,7 @@ def iter_level_nodes(enemy_nodes, enemy_roads, num_roads, zero_nodes):
             First element is level (roads needed to get there).
             Second element is set of node_ids reachable at this level.
             Third is mapping of NodeId to the list of edges
-                that leads to shortest path to that NodeId.
+            that leads to shortest path to that NodeId.
     """
     last_layer_nodes = zero_nodes
     paths = {i: [] for i in zero_nodes}

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,25 +3,29 @@ Babel==2.9.1
 beautifulsoup4==4.9.3
 certifi==2021.5.30
 chardet==4.0.0
+cloudpickle==2.1.0
 colorama==0.4.4
 decorator==4.4.2
 docutils==0.16
+gym==0.21.0
 idna==2.10
 imagesize==1.2.0
+importlib-metadata==4.12.0
 Jinja2==3.0.1
-m2r2==0.2.8
+m2r2==0.3.2
 MarkupSafe==2.0.1
-mistune==2.0.3
+mistune==0.8.4
 networkx==2.5.1
+numpy==1.23.1
 packaging==20.9
-pydata-sphinx-theme==0.6.3
+pydata-sphinx-theme==0.9.0
 Pygments==2.9.0
 pyparsing==2.4.7
 pytz==2021.1
 requests==2.25.1
 snowballstemmer==2.1.0
 soupsieve==2.2.1
-Sphinx==4.0.2
+Sphinx==5.0.2
 sphinxcontrib-applehelp==1.0.2
 sphinxcontrib-devhelp==1.0.2
 sphinxcontrib-htmlhelp==2.0.0
@@ -29,5 +33,6 @@ sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.5
 urllib3==1.26.6
+zipp==3.8.1
 -e catanatron_core
 -e catanatron_gym


### PR DESCRIPTION
This just updates a couple build dependencies and tries out the new "Build PRs" functionality from readthedocs.org.

It seems will be stuck with mistune==0.8.4 for now.

![Screen Shot 2022-07-17 at 7 50 49 PM](https://user-images.githubusercontent.com/982382/179429831-be1c5170-9e45-425a-99ed-5094dde732b7.png)
