### PR TITLE
Speed up Catanatron performance by adding caches and removing unnecessary copy-ing

### DIFF
--- a/Dockerfile.paperspace
+++ b/Dockerfile.paperspace
@@ -4,7 +4,7 @@
 #   `docker run --rm -it bcollazo/paperspace-rl catanatron-play` to ensure it works.
 #   `docker push bcollazo/paperspace-rl` to publish.
 # FROM paperspace/tensorflow:2.0.0-gpu-py3-jupyter-lab
-FROM tensorflow/tensorflow:latest-gpu-jupyter
+FROM tensorflow/tensorflow:2.10.0rc1-gpu-jupyter
 
 # Install Python3.8
 RUN apt update && \

--- a/catanatron_core/catanatron/game.py
+++ b/catanatron_core/catanatron/game.py
@@ -65,7 +65,6 @@ class Game:
         vps_to_win: int = 10,
         catan_map: CatanMap = None,
         initialize: bool = True,
-        disable_accumulator_copy = True,
     ):
         """Creates a game (doesn't run it).
 
@@ -77,7 +76,6 @@ class Game:
             catan_map (CatanMap, optional): Map to use. Defaults to None.
             initialize (bool, optional): Whether to initialize. Defaults to True.
         """
-        self.disable_accumulator_copy = disable_accumulator_copy
         if initialize:
             self.seed = seed or random.randrange(sys.maxsize)
             random.seed(self.seed)
@@ -99,18 +97,12 @@ class Game:
         Returns:
             Color: winning color or None if game exceeded TURNS_LIMIT
         """
-        initial_game_state = self
-        if not self.disable_accumulator_copy:
-            initial_game_state = self.copy()
         for accumulator in accumulators:
-            accumulator.before(initial_game_state)
+            accumulator.before(self)
         while self.winning_color() is None and self.state.num_turns < TURNS_LIMIT:
             self.play_tick(decide_fn=decide_fn, accumulators=accumulators)
-        final_game_state = self
-        if not self.disable_accumulator_copy:
-            final_game_state = self.copy()
         for accumulator in accumulators:
-            accumulator.after(final_game_state)
+            accumulator.after(self)
         return self.winning_color()
 
     def play_tick(self, decide_fn=None, accumulators=[]):
@@ -133,11 +125,8 @@ class Game:
         )
         # Call accumulator.step here, because we want game_before_action, action
         if len(accumulators) > 0:
-            game_snapshot = self
-            if not self.disable_accumulator_copy:
-                game_snapshot = self.copy()
             for accumulator in accumulators:
-                accumulator.step(game_snapshot, action)
+                accumulator.step(self, action)
         return self.execute(action)
 
     def execute(self, action: Action, validate_action: bool = True) -> Action:

--- a/catanatron_core/catanatron/game.py
+++ b/catanatron_core/catanatron/game.py
@@ -65,6 +65,7 @@ class Game:
         vps_to_win: int = 10,
         catan_map: CatanMap = None,
         initialize: bool = True,
+        disable_accumulator_copy = True,
     ):
         """Creates a game (doesn't run it).
 
@@ -76,6 +77,7 @@ class Game:
             catan_map (CatanMap, optional): Map to use. Defaults to None.
             initialize (bool, optional): Whether to initialize. Defaults to True.
         """
+        self.disable_accumulator_copy = disable_accumulator_copy
         if initialize:
             self.seed = seed or random.randrange(sys.maxsize)
             random.seed(self.seed)
@@ -97,12 +99,16 @@ class Game:
         Returns:
             Color: winning color or None if game exceeded TURNS_LIMIT
         """
-        initial_game_state = self.copy()
+        initial_game_state = self
+        if not self.disable_accumulator_copy:
+            initial_game_state = self.copy()
         for accumulator in accumulators:
             accumulator.before(initial_game_state)
         while self.winning_color() is None and self.state.num_turns < TURNS_LIMIT:
             self.play_tick(decide_fn=decide_fn, accumulators=accumulators)
-        final_game_state = self.copy()
+        final_game_state = self
+        if not self.disable_accumulator_copy:
+            final_game_state = self.copy()
         for accumulator in accumulators:
             accumulator.after(final_game_state)
         return self.winning_color()
@@ -127,7 +133,9 @@ class Game:
         )
         # Call accumulator.step here, because we want game_before_action, action
         if len(accumulators) > 0:
-            game_snapshot = self.copy()
+            game_snapshot = self
+            if not self.disable_accumulator_copy:
+                game_snapshot = self.copy()
             for accumulator in accumulators:
                 accumulator.step(game_snapshot, action)
         return self.execute(action)

--- a/catanatron_core/catanatron/models/actions.py
+++ b/catanatron_core/catanatron/models/actions.py
@@ -252,7 +252,7 @@ def maritime_trade_possibilities(state, color) -> List[Action]:
     hand_freqdeck = [
         player_num_resource_cards(state, color, resource) for resource in RESOURCES
     ]
-    port_resources = set(state.board.get_player_port_resources(color))
+    port_resources = state.board.get_player_port_resources(color)
     trade_offers = inner_maritime_trade_possibilities(
         hand_freqdeck, state.resource_freqdeck, port_resources
     )

--- a/catanatron_core/catanatron/models/board.py
+++ b/catanatron_core/catanatron/models/board.py
@@ -245,9 +245,6 @@ class Board:
 
         self.buildings[node_id] = (color, CITY)
 
-        # Reset buildable_edges
-        self.buildable_edges_cache = {}
-
     def buildable_node_ids(self, color: Color, initial_build_phase=False):
         if initial_build_phase:
             return sorted(list(self.board_buildable_ids))

--- a/catanatron_core/catanatron/models/board.py
+++ b/catanatron_core/catanatron/models/board.py
@@ -58,9 +58,6 @@ class Board:
 
     def __init__(self, catan_map=None, initialize=True):
         self.buildable_subgraph = None
-
-        # Set must_recompute_buildable_edges to true after an action that potentially changes
-        # the buildable edges
         self.buildable_edges_cache = {}
         self.player_port_resources_cache = {}
         if initialize:

--- a/catanatron_core/catanatron/models/board.py
+++ b/catanatron_core/catanatron/models/board.py
@@ -61,6 +61,7 @@ class Board:
         # Set must_recompute_buildable_edges to true after an action that potentially changes
         # the buildable edges
         self.buildable_edges_cache = {}
+        self.player_port_resources_cache = {}
         if initialize:
             self.map: CatanMap = catan_map or CatanMap.from_template(
                 BASE_MAP_TEMPLATE
@@ -154,6 +155,8 @@ class Board:
 
         # Reset buildable_edges
         self.buildable_edges_cache = {}
+        # Reset port resources
+        self.player_port_resources_cache = {}
         return previous_road_color, self.road_color, self.road_lengths
 
     def bfs_walk(self, node_id, color):
@@ -282,10 +285,17 @@ class Board:
 
     def get_player_port_resources(self, color):
         """Yields resources (None for 3:1) of ports owned by color"""
+        if color in self.player_port_resources_cache:
+            return self.player_port_resources_cache[color]
+        
+        resources = set()
         for resource, node_ids in self.map.port_nodes.items():
             for node_id in node_ids:
                 if self.get_node_color(node_id) == color:
-                    yield resource
+                    resources.add(resource)
+
+        self.player_port_resources_cache[color] = resources
+        return resources
 
     def find_connected_components(self, color: Color):
         """

--- a/tests/test_accumulators.py
+++ b/tests/test_accumulators.py
@@ -26,7 +26,7 @@ def test_accumulators():
             self.initialized = True
 
         def step(self, game, action):
-            self.games.append(game)
+            self.games.append(game.copy())
             self.actions.append(action)
 
         def after(self, game):


### PR DESCRIPTION
Implements 4 different optimizations:

- Disable accumulator copy
   - Copying is quite expensive, the code currently copies on every step when there is an accumulator used. This defaults to not copying and adds functionality to override if wanted.
- Cache buildable subgraph
  - The buildable subgraph doesn't change during the game since it only relies on the land tiles. We should just compute this once and re-use. To make this easy to change in the code I've implemented this cache as a lazy-compute.
- Cache buildable edges
  - Buildable edges don't always change, they only change when building an edge. So we cache unless a build action is done.
- Cache port resources
    Port resources only change when a settlement is built, this improvement caches the port resources and clears the cache when a settlement is built.

Together, these improvements speed up catanatron to 2.4x of its original speed. Disabling the accumulator copy was the majority of the gain. Some numbers:
![Screen Shot 2022-08-21 at 4 12 20 PM](https://user-images.githubusercontent.com/3202371/185809127-fb65e30a-e35b-4e77-a274-ddde9d208336.png)



Note:

Changing the accumulator behavior does break one of the accumulator tests. I'm looking into this.