### PR TITLE
Implement Domestic Trading Mechanics

### DIFF
--- a/catanatron_core/catanatron/game.py
+++ b/catanatron_core/catanatron/game.py
@@ -17,18 +17,18 @@ from catanatron.models.player import Color, Player
 TURNS_LIMIT = 1000
 
 
-def is_valid_action(game, action):
+def is_valid_action(state, action):
     """True if its a valid action right now. An action is valid
     if its in playable_actions or if its a OFFER_TRADE in the right time."""
     if action.action_type == ActionType.OFFER_TRADE:
         return (
-            game.state.current_color() == action.color
-            and game.state.current_prompt == ActionPrompt.PLAY_TURN
-            and player_has_rolled(game.state, action.color)
+            state.current_color() == action.color
+            and state.current_prompt == ActionPrompt.PLAY_TURN
+            and player_has_rolled(state, action.color)
             and is_valid_trade(action.value)
         )
 
-    return action in game.state.playable_actions
+    return action in state.playable_actions
 
 
 def is_valid_trade(action_value):
@@ -160,7 +160,7 @@ class Game:
 
     def execute(self, action: Action, validate_action: bool = True) -> Action:
         """Internal call that carries out decided action by player"""
-        if validate_action and not is_valid_action(self, action):
+        if validate_action and not is_valid_action(self.state, action):
             raise ValueError(
                 f"{action} not playable right now. playable_actions={self.state.playable_actions}"
             )

--- a/catanatron_core/catanatron/game.py
+++ b/catanatron_core/catanatron/game.py
@@ -7,14 +7,43 @@ import random
 import sys
 from typing import Iterable, Union
 
-from catanatron.models.enums import Action
+from catanatron.models.enums import Action, ActionPrompt, ActionType
 from catanatron.state import State, apply_action
-from catanatron.state_functions import player_key
+from catanatron.state_functions import player_key, player_has_rolled
 from catanatron.models.map import CatanMap
 from catanatron.models.player import Color, Player
 
 # To timeout RandomRobots from getting stuck...
 TURNS_LIMIT = 1000
+
+
+def is_valid_action(game, action):
+    """True if its a valid action right now. An action is valid
+    if its in playable_actions or if its a OFFER_TRADE in the right time."""
+    if action.action_type == ActionType.OFFER_TRADE:
+        return (
+            game.state.current_color() == action.color
+            and game.state.current_prompt == ActionPrompt.PLAY_TURN
+            and player_has_rolled(game.state, action.color)
+            and is_valid_trade(action.value)
+        )
+
+    return action in game.state.playable_actions
+
+
+def is_valid_trade(action_value):
+    """Checks the value of a OFFER_TRADE does not
+    give away resources or trade matching resources.
+    """
+    offering = action_value[:5]
+    asking = action_value[5:]
+    if sum(offering) == 0 or sum(asking) == 0:
+        return False  # cant give away cards
+
+    for i, j in zip(offering, asking):
+        if i > 0 and j > 0:
+            return False  # cant trade same resources
+    return True
 
 
 class GameAccumulator:
@@ -131,9 +160,9 @@ class Game:
 
     def execute(self, action: Action, validate_action: bool = True) -> Action:
         """Internal call that carries out decided action by player"""
-        if validate_action and action not in self.state.playable_actions:
+        if validate_action and not is_valid_action(self, action):
             raise ValueError(
-                f"{action} not in playable actions: {self.state.playable_actions}"
+                f"{action} not playable right now. playable_actions={self.state.playable_actions}"
             )
 
         return apply_action(self.state, action)

--- a/catanatron_core/catanatron/models/actions.py
+++ b/catanatron_core/catanatron/models/actions.py
@@ -30,6 +30,7 @@ from catanatron.models.enums import (
 )
 from catanatron.state_functions import (
     get_player_buildings,
+    get_player_freqdeck,
     player_can_afford_dev_card,
     player_can_play_dev,
     player_has_rolled,
@@ -89,8 +90,32 @@ def generate_playable_actions(state) -> List[Action]:
         return actions
     elif action_prompt == ActionPrompt.DISCARD:
         return discard_possibilities(color)
+    elif action_prompt == ActionPrompt.DECIDE_TRADE:
+        actions = [Action(color, ActionType.REJECT_TRADE, state.current_trade)]
+
+        # can only accept if have enough cards
+        freqdeck = get_player_freqdeck(state, color)
+        asked = state.current_trade[5:10]
+        if freqdeck_contains(freqdeck, asked):
+            actions.append(Action(color, ActionType.ACCEPT_TRADE, state.current_trade))
+
+        return actions
+    elif action_prompt == ActionPrompt.DECIDE_ACCEPTEES:
+        # you should be able to accept for each of the "accepting players"
+        actions = [Action(color, ActionType.CANCEL_TRADE, None)]
+
+        for (other_color, accepted) in zip(state.colors, state.acceptees):
+            if accepted:
+                actions.append(
+                    Action(
+                        color,
+                        ActionType.CONFIRM_TRADE,
+                        (*state.current_trade[:10], other_color),
+                    )
+                )
+        return actions
     else:
-        raise RuntimeError("Unknown ActionPrompt")
+        raise RuntimeError("Unknown ActionPrompt: " + str(action_prompt))
 
 
 def monopoly_possibilities(color) -> List[Action]:

--- a/catanatron_core/catanatron/models/decks.py
+++ b/catanatron_core/catanatron/models/decks.py
@@ -1,3 +1,8 @@
+"""Providers helper functions to deal with representations of decks of cards
+
+We use a histogram / 'frequency list' to represent decks (aliased 'freqdeck').
+This representation is concise, easy to copy, access and fast to compare.
+"""
 from typing import Iterable, List
 
 from catanatron.models.enums import (

--- a/catanatron_core/catanatron/models/enums.py
+++ b/catanatron_core/catanatron/models/enums.py
@@ -42,6 +42,8 @@ class ActionPrompt(Enum):
     PLAY_TURN = "PLAY_TURN"
     DISCARD = "DISCARD"
     MOVE_ROBBER = "MOVE_ROBBER"
+    DECIDE_TRADE = "DECIDE_TRADE"
+    DECIDE_ACCEPTEES = "DECIDE_ACCEPTEES"
 
 
 class ActionType(Enum):
@@ -67,12 +69,19 @@ class ActionType(Enum):
     PLAY_MONOPOLY = "PLAY_MONOPOLY"  # value is Resource
     PLAY_ROAD_BUILDING = "PLAY_ROAD_BUILDING"  # value is None
 
-    # Trade
+    # ===== Trade
     # MARITIME_TRADE value is 5-resouce tuple, where last resource is resource asked.
     #   resources in index 2 and 3 might be None, denoting a port-trade.
     MARITIME_TRADE = "MARITIME_TRADE"
-
-    # TODO: Domestic trade. Im thinking should contain SUGGEST_TRADE, ACCEPT_TRADE actions...
+    # Domestic Trade (player to player trade)
+    # Values for all three is a 10-resource tuple, first 5 is offered freqdeck, last 5 is
+    #   receiving freqdeck.
+    OFFER_TRADE = "OFFER_TRADE"
+    ACCEPT_TRADE = "ACCEPT_TRADE"
+    REJECT_TRADE = "REJECT_TRADE"
+    # CONFIRM_TRADE value is 11-tuple. first 10 as in OFFER_TRADE, last is color of accepting player
+    CONFIRM_TRADE = "CONFIRM_TRADE"
+    CANCEL_TRADE = "CANCEL_TRADE"  # value is None
 
     END_TURN = "END_TURN"  # value is None
 

--- a/catanatron_core/catanatron/models/player.py
+++ b/catanatron_core/catanatron/models/player.py
@@ -22,7 +22,8 @@ class Player:
         self.is_bot = is_bot
 
     def decide(self, game, playable_actions):
-        """Should return one of the playable_actions.
+        """Should return one of the playable_actions or
+        an OFFER_TRADE action if its your turn and you have already rolled.
 
         Args:
             game (Game): complete game state. read-only.

--- a/catanatron_core/catanatron/state.py
+++ b/catanatron_core/catanatron/state.py
@@ -5,7 +5,7 @@ Module with main State class and main apply_action call (game controller).
 import random
 import pickle
 from collections import defaultdict
-from typing import Any, List
+from typing import Any, List, Tuple
 
 from catanatron.models.map import BASE_MAP_TEMPLATE, CatanMap
 from catanatron.models.board import Board
@@ -166,6 +166,10 @@ class State:
             self.is_road_building = False
             self.free_roads_available = 0
 
+            self.is_resolving_trade = False
+            self.current_trade: Tuple = (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+            self.acceptees = tuple(False for _ in self.colors)
+
             self.playable_actions = generate_playable_actions(self)
 
     def current_player(self):
@@ -213,6 +217,10 @@ class State:
         state_copy.is_moving_knight = self.is_moving_knight
         state_copy.is_road_building = self.is_road_building
         state_copy.free_roads_available = self.free_roads_available
+
+        state_copy.is_resolving_trade = self.is_resolving_trade
+        state_copy.current_trade = self.current_trade
+        state_copy.acceptees = self.acceptees
 
         state_copy.playable_actions = self.playable_actions
         return state_copy
@@ -591,9 +599,90 @@ def apply_action(state: State, action: Action):
         # state.current_player_index stays the same
         state.current_prompt = ActionPrompt.PLAY_TURN
         state.playable_actions = generate_playable_actions(state)
+    elif action.action_type == ActionType.OFFER_TRADE:
+        state.is_resolving_trade = True
+        state.current_trade = (*action.value, state.current_turn_index)
+
+        # go in seating order; order won't matter because of "acceptees hook"
+        state.current_player_index = next(
+            i for i, c in enumerate(state.colors) if c != action.color
+        )  # cant ask yourself
+        state.current_prompt = ActionPrompt.DECIDE_TRADE
+
+        state.playable_actions = generate_playable_actions(state)
+    elif action.action_type == ActionType.ACCEPT_TRADE:
+        # add yourself to self.acceptees
+        index = state.colors.index(action.color)
+        new_acceptess = list(state.acceptees)
+        new_acceptess[index] = True  # type: ignore
+        state.acceptees = tuple(new_acceptess)
+
+        try:
+            # keep going around table w/o asking yourself or players that have answered
+            state.current_player_index = next(
+                i
+                for i, c in enumerate(state.colors)
+                if c != action.color and i > state.current_player_index
+            )
+            # .is_resolving_trade, .current_trade, .current_prompt, .acceptees stay the same
+        except StopIteration:
+            # by this action, there is at least 1 acceptee, so go to DECIDE_ACCEPTEES
+            # .is_resolving_trade, .current_trade, .acceptees stay the same
+            state.current_player_index = state.current_turn_index
+            state.current_prompt = ActionPrompt.DECIDE_ACCEPTEES
+
+        state.playable_actions = generate_playable_actions(state)
+    elif action.action_type == ActionType.REJECT_TRADE:
+        try:
+            # keep going around table w/o asking yourself or players that have answered
+            state.current_player_index = next(
+                i
+                for i, c in enumerate(state.colors)
+                if c != action.color and i > state.current_player_index
+            )
+            # .is_resolving_trade, .current_trade, .current_prompt, .acceptees stay the same
+        except StopIteration:
+            # if no acceptees at this point, go back to PLAY_TURN
+            if sum(state.acceptees) == 0:
+                reset_trading_state(state)
+
+                state.current_player_index = state.current_turn_index
+                state.current_prompt = ActionPrompt.PLAY_TURN
+            else:
+                # go to offering player with all the answers
+                # .is_resolving_trade, .current_trade, .acceptees stay the same
+                state.current_player_index = state.current_turn_index
+                state.current_prompt = ActionPrompt.DECIDE_ACCEPTEES
+
+        state.playable_actions = generate_playable_actions(state)
+    elif action.action_type == ActionType.CONFIRM_TRADE:
+        # apply trade
+        offering = action.value[:5]
+        asking = action.value[5:10]
+        enemy = action.value[10]
+        player_freqdeck_subtract(state, action.color, offering)
+        player_freqdeck_add(state, action.color, asking)
+        player_freqdeck_subtract(state, enemy, asking)
+        player_freqdeck_add(state, enemy, offering)
+
+        reset_trading_state(state)
+
+        state.current_player_index = state.current_turn_index
+        state.current_prompt = ActionPrompt.PLAY_TURN
+    elif action.action_type == ActionType.CANCEL_TRADE:
+        reset_trading_state(state)
+
+        state.current_player_index = state.current_turn_index
+        state.current_prompt = ActionPrompt.PLAY_TURN
     else:
         raise ValueError("Unknown ActionType " + str(action.action_type))
 
     # TODO: Think about possible-action/idea vs finalized-action design
     state.actions.append(action)
     return action
+
+
+def reset_trading_state(state):
+    state.is_resolving_trade = False
+    state.current_trade = (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+    state.acceptees = tuple(False for _ in state.colors)

--- a/catanatron_core/catanatron/state.py
+++ b/catanatron_core/catanatron/state.py
@@ -659,11 +659,11 @@ def apply_action(state: State, action: Action):
         # apply trade
         offering = action.value[:5]
         asking = action.value[5:10]
-        enemy = action.value[10]
+        enemy_color = action.value[10]
         player_freqdeck_subtract(state, action.color, offering)
         player_freqdeck_add(state, action.color, asking)
-        player_freqdeck_subtract(state, enemy, asking)
-        player_freqdeck_add(state, enemy, offering)
+        player_freqdeck_subtract(state, enemy_color, asking)
+        player_freqdeck_add(state, enemy_color, offering)
 
         reset_trading_state(state)
 

--- a/catanatron_core/catanatron/state_functions.py
+++ b/catanatron_core/catanatron/state_functions.py
@@ -134,6 +134,17 @@ def get_player_buildings(state, color_param, building_type_param):
     return state.buildings_by_color[color_param][building_type_param]
 
 
+def get_player_freqdeck(state, color):
+    key = player_key(state, color)
+    return [
+        state.player_state[f"{key}_WOOD_IN_HAND"],
+        state.player_state[f"{key}_BRICK_IN_HAND"],
+        state.player_state[f"{key}_SHEEP_IN_HAND"],
+        state.player_state[f"{key}_WHEAT_IN_HAND"],
+        state.player_state[f"{key}_ORE_IN_HAND"],
+    ]
+
+
 # ===== State Mutators
 def build_settlement(state, color, node_id, is_free):
     state.buildings_by_color[color][SETTLEMENT].append(node_id)

--- a/catanatron_core/catanatron/state_functions.py
+++ b/catanatron_core/catanatron/state_functions.py
@@ -135,6 +135,7 @@ def get_player_buildings(state, color_param, building_type_param):
 
 
 def get_player_freqdeck(state, color):
+    """Returns a 'freqdeck' of a player's resource hand."""
     key = player_key(state, color)
     return [
         state.player_state[f"{key}_WOOD_IN_HAND"],


### PR DESCRIPTION
This PR introduces 5 new "actions" that allow player-to-player trading mechanics to ensue.
- OFFER_TRADE
- ACCEPT_TRADE (to answer if asked)
- REJECT_TRADE (to answer if asked)
- CONFIRM_TRADE (so that players can select with whom to proceed if multiple players accepted offer)
- CANCEL_TRADE (so that players can "regret" offering trades)

Because the space of possible "trade offers" a player can make is infinite, we keep trading actions outside of the `playable_actions` that is generated on every turn. In particular, now "valid actions" are anything inside the `playable_actions` array _or_ an OFFER_TRADE action that is made at the right time by the right player with right resources.

To implement the "control sequence" that the `Game` class must carry out when a trade is offered (a OFFER_TRADE action is played), we added the following three attributes to the `State` class:
 
- is_resolving_trade
- current_trade
- acceptees

which in combination to `current_player_index`, `current_turn_index`, and the two new values to `current_prompt` (DECIDE_TRADE and DECIDE_ACCEPTEES) should be enough to know should the next tick advance the game.


The control sequence triggered after an OFFER_TRADE is:
1. Iterate over each player (in seating order, because might as well) collecting their "answer" to the offer. In particular, each `play_tick` will be calling the `.decide` of these players with two playable actions (ACCEPT_TRADE or REJECT_TRADE).
2. If all players rejected, go back to the `PLAY_TURN` state the offering player was in.
3. If at least one player accepted offer, go back to the offering player with a `CANCEL_TRADE` action and one `CONFIRM_TRADE` for each accepting player (acceptee). This decision will either apply the trade and go back to the `PLAY_TURN` of the offering player or just go back to `PLAY_TURN` of the offering player.
