### PR TITLE
Remove -p option from CLI

### DIFF
--- a/catanatron_experimental/catanatron_experimental/play.py
+++ b/catanatron_experimental/catanatron_experimental/play.py
@@ -61,7 +61,6 @@ class CustomTimeRemainingColumn(TimeRemainingColumn):
 @click.command()
 @click.option("-n", "--num", default=5, help="Number of games to play.")
 @click.option(
-    "-p",
     "--players",
     default="R,R,R,R",
     help="""


### PR DESCRIPTION
See https://github.com/bcollazo/catanatron/issues/207. The idea is to avoid users accidentally using `-players=...`.
