### PR TITLE
Implement faster winner check

### DIFF
--- a/catanatron_core/catanatron/game.py
+++ b/catanatron_core/catanatron/game.py
@@ -110,8 +110,9 @@ class Game:
             random.seed(self.seed)
 
             self.id = str(uuid.uuid4())
-            self.vps_to_win = vps_to_win
-            self.state = State(players, catan_map, discard_limit=discard_limit)
+            self.state = State(
+                players, catan_map, discard_limit=discard_limit, vps_to_win=vps_to_win
+            )
 
     def play(self, accumulators=[], decide_fn=None):
         """Executes game until a player wins or exceeded TURNS_LIMIT.
@@ -173,16 +174,7 @@ class Game:
         Returns:
             Union[Color, None]: Might be None if game truncated by TURNS_LIMIT
         """
-        result = None
-        for color in self.state.colors:
-            key = player_key(self.state, color)
-            if (
-                self.state.player_state[f"{key}_ACTUAL_VICTORY_POINTS"]
-                >= self.vps_to_win
-            ):
-                result = color
-
-        return result
+        return self.state.winning_color
 
     def copy(self) -> "Game":
         """Creates a copy of this Game, that can be modified without
@@ -194,6 +186,5 @@ class Game:
         game_copy = Game([], None, None, initialize=False)
         game_copy.seed = self.seed
         game_copy.id = self.id
-        game_copy.vps_to_win = self.vps_to_win
         game_copy.state = self.state.copy()
         return game_copy

--- a/catanatron_core/catanatron/state.py
+++ b/catanatron_core/catanatron/state.py
@@ -49,6 +49,7 @@ from catanatron.state_functions import (
     player_can_afford_dev_card,
     player_can_play_dev,
     player_clean_turn,
+    player_check_is_winner,
     player_freqdeck_add,
     player_deck_draw,
     player_deck_random_draw,
@@ -120,6 +121,8 @@ class State:
         free_roads_available (int): Number of roads available left in Road Building
             phase.
         playable_actions (List[Action]): List of playable actions by current player.
+        vps_to_win (int): Number of VPS points needed to win.
+        winning_color (bool): If there is a winner, store the winner's color. Othewrise None.
     """
 
     def __init__(
@@ -127,6 +130,7 @@ class State:
         players: List[Any],
         catan_map=None,
         discard_limit=7,
+        vps_to_win=10,
         initialize=True,
     ):
         if initialize:
@@ -171,6 +175,8 @@ class State:
             self.acceptees = tuple(False for _ in self.colors)
 
             self.playable_actions = generate_playable_actions(self)
+            self.vps_to_win = vps_to_win
+            self.winning_color = None
 
     def current_player(self):
         """Helper for accessing Player instance who should decide next"""
@@ -223,6 +229,9 @@ class State:
         state_copy.acceptees = self.acceptees
 
         state_copy.playable_actions = self.playable_actions
+
+        state_copy.vps_to_win = self.vps_to_win
+        state_copy.winning_color = self.winning_color
         return state_copy
 
 
@@ -320,6 +329,7 @@ def apply_action(state: State, action: Action):
 
     if action.action_type == ActionType.END_TURN:
         player_clean_turn(state, action.color)
+        player_check_is_winner(state, action.color)
         advance_turn(state)
         state.current_prompt = ActionPrompt.PLAY_TURN
         state.playable_actions = generate_playable_actions(state)

--- a/catanatron_core/catanatron/state_functions.py
+++ b/catanatron_core/catanatron/state_functions.py
@@ -323,3 +323,9 @@ def player_clean_turn(state, color):
     key = player_key(state, color)
     state.player_state[f"{key}_HAS_PLAYED_DEVELOPMENT_CARD_IN_TURN"] = False
     state.player_state[f"{key}_HAS_ROLLED"] = False
+
+
+def player_check_is_winner(state, color):
+    key = player_key(state, color)
+    if state.player_state[f"{key}_ACTUAL_VICTORY_POINTS"] >= state.vps_to_win:
+        state.winning_color = color


### PR DESCRIPTION
Reworks the logic that checks for a winner. The new implementation checks after the end of each turn for the current player vs. the current implementation that loops over each player and checks if there's a winner.

Currently, the code loops over each player after each tick to determine if there's a winner. However, we can simply check if a player has won in their turn and store that information. This saves us from looping over the players after each tick which accounts for 5% of the runtime.

I found this by running a profiler and viewing the output through snakeviz:
```
$ python3.9 -m cProfile -o profile play.py --num=1000
$ snakeviz ./profile
``` 
<img width="1509" alt="Screen Shot 2022-09-11 at 12 20 30 PM" src="https://user-images.githubusercontent.com/3202371/189538330-40b5e630-9819-4d33-9b2d-17de5469f66b.png">

We can notice a speed improvement in the overall runtime by running
```time python3.9  play.py --num=1000```

At commit `aa43d9`, the current head commit, my machine computes an average duration per game of 0.023s.

In this commit, the average duration per game is 0.022s. Roughly a 4.5% improvement which correlates with the snakeviz graph.

The updated snakeviz profile shows that `winning_color` now accounts for only 0.21% of the runtime.
<img width="1508" alt="Screen Shot 2022-09-11 at 12 32 24 PM" src="https://user-images.githubusercontent.com/3202371/189538891-c9b3a23d-8d16-4a34-b22d-c681abe9ec8d.png">

