### PR TITLE
Remove unnecessary 'global' keyword uses

### DIFF
--- a/catanatron_core/catanatron/models/board.py
+++ b/catanatron_core/catanatron/models/board.py
@@ -28,13 +28,11 @@ for tile in base_map.tiles.values():
 
 @functools.lru_cache(1)
 def get_node_distances():
-    global STATIC_GRAPH
     return nx.floyd_warshall(STATIC_GRAPH)
 
 
 @functools.lru_cache(3)  # None, range(54), range(24)
 def get_edges(land_nodes=None):
-    global STATIC_GRAPH, NUM_NODES
     return list(STATIC_GRAPH.subgraph(land_nodes or range(NUM_NODES)).edges())
 
 
@@ -83,7 +81,6 @@ class Board:
             ).__next__()
 
             # Cache buildable subgraph
-            global STATIC_GRAPH
             self.buildable_subgraph = STATIC_GRAPH.subgraph(self.map.land_nodes)
 
     def build_settlement(self, color, node_id, initial_build_phase=False):
@@ -347,8 +344,6 @@ class Board:
 
 
 def longest_acyclic_path(board: Board, node_set: Set[int], color: Color):
-    global STATIC_GRAPH
-
     paths = []
     for start_node in node_set:
         # do DFS when reach leaf node, stop and add to paths

--- a/catanatron_gym/catanatron_gym/board_tensor_features.py
+++ b/catanatron_gym/catanatron_gym/board_tensor_features.py
@@ -67,7 +67,6 @@ def get_tile_coordinate_map():
 
 # Create mapping of node_id => i,j and edge => i,j. Respecting (WIDTH, HEIGHT)
 def init_board_tensor_map():
-    global STATIC_GRAPH
     # These are node-pairs (start,end) for the lines that go from left to right
     pairs = [
         (82, 93),

--- a/catanatron_gym/catanatron_gym/features.py
+++ b/catanatron_gym/catanatron_gym/features.py
@@ -377,7 +377,6 @@ def count_production(nodes, catan_map):
 
 
 def expansion_features(game: Game, p0_color: Color):
-    global STATIC_GRAPH
     MAX_EXPANSION_DISTANCE = 3  # exclusive
 
     features = {}


### PR DESCRIPTION
The `global` keyword should be used when the variable in question is being assigned to as otherwise it would create a local variable as opposed to operating on the global variable.

I.e.

```
global STATIC_GRAPH
STATIC_GRAPH = new_graph()
```

This PR removes uses of `global` in cases where the variable is only being accessed and not assigned to.