### PR TITLE
Fix dev card hallucination bug and other expand_spectrum changes

### DIFF
--- a/catanatron_core/catanatron/state_functions.py
+++ b/catanatron_core/catanatron/state_functions.py
@@ -65,8 +65,10 @@ def mantain_largets_army(state, color, previous_army_color, previous_army_size):
 def player_key(state, color):
     return f"P{state.color_to_index[color]}"
 
+
 def get_enemy_colors(colors, player_color):
     return filter(lambda c: c != player_color, colors)
+
 
 def get_actual_victory_points(state, color):
     key = player_key(state, color)

--- a/catanatron_core/catanatron/state_functions.py
+++ b/catanatron_core/catanatron/state_functions.py
@@ -65,6 +65,8 @@ def mantain_largets_army(state, color, previous_army_color, previous_army_size):
 def player_key(state, color):
     return f"P{state.color_to_index[color]}"
 
+def get_enemy_colors(colors, player_color):
+    return filter(lambda c: c != player_color, colors)
 
 def get_actual_victory_points(state, color):
     key = player_key(state, color)

--- a/catanatron_experimental/catanatron_experimental/machine_learning/players/tree_search_utils.py
+++ b/catanatron_experimental/catanatron_experimental/machine_learning/players/tree_search_utils.py
@@ -3,6 +3,7 @@ from collections import defaultdict
 
 from catanatron.models.map import number_probability
 from catanatron.models.enums import (
+    DEVELOPMENT_CARDS,
     RESOURCES,
     SETTLEMENT,
     CITY,
@@ -10,7 +11,7 @@ from catanatron.models.enums import (
     ActionType,
 )
 
-from catanatron.state_functions import get_player_buildings
+from catanatron.state_functions import get_player_buildings, get_dev_cards_in_hand
 from catanatron_gym.features import (
     build_production_features,
 )
@@ -40,7 +41,17 @@ def execute_spectrum(game, action):
         return [(copy, 1)]
     elif action.action_type == ActionType.BUY_DEVELOPMENT_CARD:
         results = []
-        current_deck = game.state.development_listdeck
+
+        # Get the possible deck from the perspective of the current player
+        # by getting all face down cards
+        current_deck = game.state.development_listdeck.copy()
+        for color in game.state.colors:
+            if color == action.color:
+                continue
+            for card in DEVELOPMENT_CARDS:
+                number = get_dev_cards_in_hand(game.state, color, card)
+                current_deck += [card]*number
+
         for card in set(current_deck):
             option_action = Action(action.color, action.action_type, card)
             option_game = game.copy()

--- a/catanatron_experimental/catanatron_experimental/machine_learning/players/tree_search_utils.py
+++ b/catanatron_experimental/catanatron_experimental/machine_learning/players/tree_search_utils.py
@@ -11,7 +11,11 @@ from catanatron.models.enums import (
     ActionType,
 )
 
-from catanatron.state_functions import get_player_buildings, get_dev_cards_in_hand, get_player_freqdeck
+from catanatron.state_functions import (
+    get_player_buildings,
+    get_dev_cards_in_hand,
+    get_player_freqdeck,
+)
 from catanatron_gym.features import (
     build_production_features,
 )
@@ -32,10 +36,12 @@ DETERMINISTIC_ACTIONS = set(
     ]
 )
 
+
 def execute_deterministic(game, action):
     copy = game.copy()
     copy.execute(action, validate_action=False)
     return [(copy, 1)]
+
 
 def execute_spectrum(game, action):
     """Returns [(game_copy, proba), ...] tuples for result of given action.
@@ -53,13 +59,13 @@ def execute_spectrum(game, action):
                 continue
             for card in DEVELOPMENT_CARDS:
                 number = get_dev_cards_in_hand(game.state, color, card)
-                current_deck += [card]*number
+                current_deck += [card] * number
 
         for card in set(current_deck):
             option_action = Action(action.color, action.action_type, card)
             option_game = game.copy()
             option_game.execute(option_action, validate_action=False)
-            results.append((option_game, current_deck.count(card)/len(current_deck)))
+            results.append((option_game, current_deck.count(card) / len(current_deck)))
         return results
     elif action.action_type == ActionType.ROLL:
         results = []

--- a/catanatron_experimental/catanatron_experimental/machine_learning/players/tree_search_utils.py
+++ b/catanatron_experimental/catanatron_experimental/machine_learning/players/tree_search_utils.py
@@ -15,6 +15,7 @@ from catanatron.state_functions import (
     get_player_buildings,
     get_dev_cards_in_hand,
     get_player_freqdeck,
+    get_enemy_colors,
 )
 from catanatron_gym.features import (
     build_production_features,
@@ -54,9 +55,7 @@ def execute_spectrum(game, action):
         # Get the possible deck from the perspective of the current player
         # by getting all face down cards
         current_deck = game.state.development_listdeck.copy()
-        for color in game.state.colors:
-            if color == action.color:
-                continue
+        for color in get_enemy_colors(game.state.colors, action.color):
             for card in DEVELOPMENT_CARDS:
                 number = get_dev_cards_in_hand(game.state, color, card)
                 current_deck += [card] * number

--- a/catanatron_experimental/catanatron_experimental/machine_learning/players/tree_search_utils.py
+++ b/catanatron_experimental/catanatron_experimental/machine_learning/players/tree_search_utils.py
@@ -2,11 +2,7 @@ import math
 from collections import defaultdict
 
 from catanatron.models.map import number_probability
-from catanatron.models.decks import (
-    starting_devcard_proba,
-)
 from catanatron.models.enums import (
-    DEVELOPMENT_CARDS,
     RESOURCES,
     SETTLEMENT,
     CITY,
@@ -44,7 +40,8 @@ def execute_spectrum(game, action):
         return [(copy, 1)]
     elif action.action_type == ActionType.BUY_DEVELOPMENT_CARD:
         results = []
-        for card in DEVELOPMENT_CARDS:
+        current_deck = game.state.development_listdeck
+        for card in set(current_deck):
             option_action = Action(action.color, action.action_type, card)
             option_game = game.copy()
             try:
@@ -54,7 +51,7 @@ def execute_spectrum(game, action):
                 # ignoring means the value function of this node will be flattened,
                 # to the one before.
                 pass
-            results.append((option_game, starting_devcard_proba(card)))
+            results.append((option_game, current_deck.count(card)/len(current_deck)))
         return results
     elif action.action_type == ActionType.ROLL:
         results = []

--- a/catanatron_experimental/catanatron_experimental/machine_learning/players/tree_search_utils.py
+++ b/catanatron_experimental/catanatron_experimental/machine_learning/players/tree_search_utils.py
@@ -63,7 +63,13 @@ def execute_spectrum(game, action):
         for card in set(current_deck):
             option_action = Action(action.color, action.action_type, card)
             option_game = game.copy()
-            option_game.execute(option_action, validate_action=False)
+            try:
+                option_game.execute(option_action, validate_action=False)
+            except Exception:
+                # ignore exceptions, since player might imagine impossible outcomes.
+                # ignoring means the value function of this node will be flattened,
+                # to the one before.
+                pass
             results.append((option_game, current_deck.count(card) / len(current_deck)))
         return results
     elif action.action_type == ActionType.ROLL:


### PR DESCRIPTION
Hi!

Changes in this PR:

- `execute_spectrum` now uses the correct knowable dev card probabilities rather than the base ones. It could get smarter and use the (unknowable) bank probabilities instead, but I didn't want to leak any info accidentally. I expect this to have a very small impact but I think is still worth merging
- `execute_spectrum` now uses the correct robber steal probabilities - based on the fact that the bot should be able to track other players hands (and therefore there's no leakage of information here). 
- Style changes. Please feel free to revert these! Just made DETERMINISTIC_ACTIONS look like a constant and added a small helper function.
- Filter actions to playable_actions before execute_spectrum and therefore remove some try blocks. This is definitely a change you might want to push back on!