### PR TITLE
Fix Mypy issues in catanatron_core

### DIFF
--- a/catanatron_core/catanatron/game.py
+++ b/catanatron_core/catanatron/game.py
@@ -5,7 +5,7 @@ Contains Game class which is a thin-wrapper around the State class.
 import uuid
 import random
 import sys
-from typing import Iterable, Union
+from typing import List, Union, Optional
 
 from catanatron.models.enums import Action, ActionPrompt, ActionType
 from catanatron.state import State, apply_action
@@ -88,17 +88,17 @@ class Game:
 
     def __init__(
         self,
-        players: Iterable[Player],
-        seed: int = None,
+        players: List[Player],
+        seed: Optional[int] = None,
         discard_limit: int = 7,
         vps_to_win: int = 10,
-        catan_map: CatanMap = None,
+        catan_map: Optional[CatanMap] = None,
         initialize: bool = True,
     ):
         """Creates a game (doesn't run it).
 
         Args:
-            players (Iterable[Player]): list of players, should be at most 4.
+            players (List[Player]): list of players, should be at most 4.
             seed (int, optional): Random seed to use (for reproducing games). Defaults to None.
             discard_limit (int, optional): Discard limit to use. Defaults to 7.
             vps_to_win (int, optional): Victory Points needed to win. Defaults to 10.
@@ -191,7 +191,7 @@ class Game:
         Returns:
             Game: Game copy.
         """
-        game_copy = Game([], None, None, initialize=False)
+        game_copy = Game(players=[], initialize=False)
         game_copy.seed = self.seed
         game_copy.id = self.id
         game_copy.vps_to_win = self.vps_to_win

--- a/catanatron_core/catanatron/models/actions.py
+++ b/catanatron_core/catanatron/models/actions.py
@@ -4,7 +4,7 @@ by current player). Main function is generate_playable_actions.
 """
 import operator as op
 from functools import reduce
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Set, Tuple, Union
 
 from catanatron.models.decks import (
     CITY_COST_FREQDECK,
@@ -123,7 +123,7 @@ def monopoly_possibilities(color) -> List[Action]:
 
 
 def year_of_plenty_possibilities(color, freqdeck: List[int]) -> List[Action]:
-    options = set()
+    options: Set[Union[Tuple[FastResource, FastResource], Tuple[FastResource]]] = set()
     for i, first_card in enumerate(RESOURCES):
         for j in range(i, len(RESOURCES)):
             second_card = RESOURCES[j]  # doing it this way to not repeat

--- a/catanatron_core/catanatron/models/board.py
+++ b/catanatron_core/catanatron/models/board.py
@@ -1,10 +1,10 @@
 import pickle
 import copy
 from collections import defaultdict
-from typing import Any, Set, Dict, Tuple
+from typing import Any, Set, Dict, Tuple, List
 import functools
 
-import networkx as nx
+import networkx as nx  # type: ignore
 
 from catanatron.models.player import Color
 from catanatron.models.map import (
@@ -55,7 +55,7 @@ class Board:
     """
 
     def __init__(self, catan_map=None, initialize=True):
-        self.buildable_subgraph = None
+        self.buildable_subgraph: Any = None
         self.buildable_edges_cache = {}
         self.player_port_resources_cache = {}
         if initialize:
@@ -348,7 +348,7 @@ def longest_acyclic_path(board: Board, node_set: Set[int], color: Color):
     for start_node in node_set:
         # do DFS when reach leaf node, stop and add to paths
         paths_from_this_node = []
-        agenda = [(start_node, [])]
+        agenda: List[Tuple[int, Any]] = [(start_node, [])]
         while len(agenda) > 0:
             node, path_thus_far = agenda.pop()
 

--- a/catanatron_core/catanatron/models/enums.py
+++ b/catanatron_core/catanatron/models/enums.py
@@ -1,6 +1,6 @@
 from enum import Enum
 from collections import namedtuple
-from typing import List, Literal
+from typing import List, Literal, Final
 
 
 FastResource = Literal["WOOD", "BRICK", "SHEEP", "WHEAT", "ORE"]
@@ -11,18 +11,18 @@ FastBuildingType = Literal["SETTLEMENT", "CITY", "ROAD"]
 
 # Strings are considerably faster than Python Enum's (e.g. at being hashed).
 # TODO: Move to ints
-WOOD = "WOOD"
-BRICK = "BRICK"
-SHEEP = "SHEEP"
-WHEAT = "WHEAT"
-ORE = "ORE"
+WOOD: Final = "WOOD"
+BRICK: Final = "BRICK"
+SHEEP: Final = "SHEEP"
+WHEAT: Final = "WHEAT"
+ORE: Final = "ORE"
 RESOURCES: List[FastResource] = [WOOD, BRICK, SHEEP, WHEAT, ORE]
 
-KNIGHT = "KNIGHT"
-YEAR_OF_PLENTY = "YEAR_OF_PLENTY"
-MONOPOLY = "MONOPOLY"
-ROAD_BUILDING = "ROAD_BUILDING"
-VICTORY_POINT = "VICTORY_POINT"
+KNIGHT: Final = "KNIGHT"
+YEAR_OF_PLENTY: Final = "YEAR_OF_PLENTY"
+MONOPOLY: Final = "MONOPOLY"
+ROAD_BUILDING: Final = "ROAD_BUILDING"
+VICTORY_POINT: Final = "VICTORY_POINT"
 DEVELOPMENT_CARDS: List[FastDevCard] = [
     KNIGHT,
     YEAR_OF_PLENTY,
@@ -86,20 +86,12 @@ class ActionType(Enum):
     END_TURN = "END_TURN"  # value is None
 
 
-def action_type_repr(self):
+def __repr__(self):
     return f"ActionType.{self.value}"
-
-
-ActionType.__repr__ = action_type_repr
-
-
-def action_repr(self):
-    return f"Action({self.color.value} {self.action_type.value} {self.value})"
 
 
 # TODO: Distinguish between Action and ActionLog?
 Action = namedtuple("Action", ["color", "action_type", "value"])
-Action.__repr__ = action_repr
 Action.__doc__ = """
 Main class to represent action. Should be immutable.
 

--- a/catanatron_core/catanatron/models/enums.py
+++ b/catanatron_core/catanatron/models/enums.py
@@ -31,9 +31,9 @@ DEVELOPMENT_CARDS: List[FastDevCard] = [
     VICTORY_POINT,
 ]
 
-SETTLEMENT = "SETTLEMENT"
-CITY = "CITY"
-ROAD = "ROAD"
+SETTLEMENT: Final = "SETTLEMENT"
+CITY: Final = "CITY"
+ROAD: Final = "ROAD"
 
 
 class ActionPrompt(Enum):

--- a/catanatron_core/catanatron/models/map.py
+++ b/catanatron_core/catanatron/models/map.py
@@ -378,7 +378,7 @@ def initialize_tiles(
     )
 
     # for each topology entry, place a tile. keep track of nodes and edges
-    all_tiles = {}
+    all_tiles: Dict[Coordinate, Tile] = {}
     node_autoinc = 0
     tile_autoinc = 0
     port_autoinc = 0

--- a/catanatron_core/catanatron/state.py
+++ b/catanatron_core/catanatron/state.py
@@ -5,7 +5,7 @@ Module with main State class and main apply_action call (game controller).
 import random
 import pickle
 from collections import defaultdict
-from typing import Any, List, Tuple, Dict
+from typing import Any, List, Tuple, Dict, Iterable
 
 from catanatron.models.map import BASE_MAP_TEMPLATE, CatanMap
 from catanatron.models.board import Board
@@ -59,8 +59,8 @@ from catanatron.state_functions import (
     player_num_resource_cards,
     player_resource_freqdeck_contains,
 )
-from catanatron.models.player import Color
-from catanatron.models.enums import FastBuildingType, FastResource
+from catanatron.models.player import Color, Player
+from catanatron.models.enums import FastResource
 
 # These will be prefixed by P0_, P1_, ...
 # Create Player State blueprint
@@ -126,7 +126,7 @@ class State:
 
     def __init__(
         self,
-        players: List[Any],
+        players: List[Player],
         catan_map=None,
         discard_limit=7,
         initialize=True,

--- a/catanatron_core/catanatron/state.py
+++ b/catanatron_core/catanatron/state.py
@@ -267,11 +267,11 @@ def yield_resources(board: Board, resource_freqdeck, number):
             if building is None:
                 continue
             elif building[1] == SETTLEMENT:
-                intented_payout[building[0]][resource] += 1
-                resource_totals[resource] += 1
+                intented_payout[building[0]][tile.resource] += 1
+                resource_totals[tile.resource] += 1
             elif building[1] == CITY:
-                intented_payout[building[0]][resource] += 2
-                resource_totals[resource] += 2
+                intented_payout[building[0]][tile.resource] += 2
+                resource_totals[tile.resource] += 2
 
     # for each resource, check enough in deck to yield.
     depleted = []

--- a/catanatron_core/catanatron/state.py
+++ b/catanatron_core/catanatron/state.py
@@ -5,7 +5,7 @@ Module with main State class and main apply_action call (game controller).
 import random
 import pickle
 from collections import defaultdict
-from typing import Any, List, Tuple
+from typing import Any, List, Tuple, Dict
 
 from catanatron.models.map import BASE_MAP_TEMPLATE, CatanMap
 from catanatron.models.board import Board
@@ -59,6 +59,8 @@ from catanatron.state_functions import (
     player_num_resource_cards,
     player_resource_freqdeck_contains,
 )
+from catanatron.models.player import Color
+from catanatron.models.enums import FastBuildingType, FastResource
 
 # These will be prefixed by P0_, P1_, ...
 # Create Player State blueprint
@@ -149,8 +151,10 @@ class State:
             random.shuffle(self.development_listdeck)
 
             # Auxiliary attributes to implement game logic
-            self.buildings_by_color = {p.color: defaultdict(list) for p in players}
-            self.actions = []  # log of all action taken by players
+            self.buildings_by_color: Dict[Color, Dict[Any, Any]] = {
+                p.color: defaultdict(list) for p in players
+            }
+            self.actions: List[Action] = []  # log of all action taken by players
             self.num_turns = 0  # num_completed_turns
 
             # Current prompt / player
@@ -249,22 +253,25 @@ def yield_resources(board: Board, resource_freqdeck, number):
             Second is an array of resources that couldn't be yieleded
             because they depleted.
     """
-    intented_payout = defaultdict(lambda: defaultdict(int))
-    resource_totals = defaultdict(int)
+    intented_payout: Dict[Color, Dict[FastResource, int]] = defaultdict(
+        lambda: defaultdict(int)
+    )
+    resource_totals: Dict[FastResource, int] = defaultdict(int)
     for (coordinate, tile) in board.map.land_tiles.items():
         if tile.number != number or board.robber_coordinate == coordinate:
             continue  # doesn't yield
 
         for _, node_id in tile.nodes.items():
             building = board.buildings.get(node_id, None)
+            assert tile.resource is not None
             if building is None:
                 continue
             elif building[1] == SETTLEMENT:
-                intented_payout[building[0]][tile.resource] += 1
-                resource_totals[tile.resource] += 1
+                intented_payout[building[0]][resource] += 1
+                resource_totals[resource] += 1
             elif building[1] == CITY:
-                intented_payout[building[0]][tile.resource] += 2
-                resource_totals[tile.resource] += 2
+                intented_payout[building[0]][resource] += 2
+                resource_totals[resource] += 2
 
     # for each resource, check enough in deck to yield.
     depleted = []

--- a/catanatron_core/catanatron/state_functions.py
+++ b/catanatron_core/catanatron/state_functions.py
@@ -4,6 +4,7 @@ Some are helpers to _read_ information from state and keep the rest
 of the code decoupled from state representation.
 """
 import random
+from typing import Optional
 
 from catanatron.models.decks import ROAD_COST_FREQDECK, freqdeck_add
 from catanatron.models.enums import (
@@ -254,7 +255,7 @@ def buy_dev_card(state, color, dev_card):
     state.player_state[f"{key}_ORE_IN_HAND"] -= 1
 
 
-def player_num_resource_cards(state, color, card: FastResource = None):
+def player_num_resource_cards(state, color, card: Optional[FastResource] = None):
     key = player_key(state, color)
     if card is None:
         return (

--- a/catanatron_core/setup.py
+++ b/catanatron_core/setup.py
@@ -1,4 +1,4 @@
-import setuptools
+import setuptools  # type: ignore
 import os
 
 readme_path = os.path.abspath(os.path.join(__file__, "..", "..", "README.md"))


### PR DESCRIPTION
Initial PR to prepare the codebase to use mypy. This PR just addresses the issues found by running:

```
$ mypy catanatron_core
```

With this PR, the output is:
```
$ mypy catanatron_core
catanatron_core/catanatron/models/board.py:58: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
catanatron_core/catanatron/models/board.py:62: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
catanatron_core/catanatron/models/board.py:66: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
catanatron_core/catanatron/models/board.py:71: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
catanatron_core/catanatron/models/actions.py:295: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
catanatron_core/catanatron/models/actions.py:306: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
Success: no issues found in 17 source files
```

Follow up PRs can make the type hints more specific and/or expand to the other subprojects.