### PR TITLE
workflow and performance tests for github actions

### DIFF
--- a/.github/workflows/perf-regression.yml
+++ b/.github/workflows/perf-regression.yml
@@ -51,11 +51,3 @@ jobs:
           # Workflow will fail if `fail-threshold` is exceeded
           fail-on-alert: true
           fail-threshold: '150%'
-
-
-
-
-
-
-
-

--- a/.github/workflows/perf-regression.yml
+++ b/.github/workflows/perf-regression.yml
@@ -8,15 +8,8 @@ on:
     branches: master
 
 jobs:
-  build-docker:
-    runs-on: ubuntu-latest
 
-    steps:
-      - uses: actions/checkout@v2
-      - name: Build the Server Docker image
-        run: docker build . -f Dockerfile.web -t bcollazo/catanatron-server:latest
-
-  build-python:
+  build-python-and-test-performance:
     runs-on: ubuntu-latest
 
     steps:
@@ -34,11 +27,7 @@ jobs:
           pip install -e catanatron_server
           pip install -e catanatron_experimental
 
-  benchmark-performance:
-    name: Time Benchmark
-    runs-on: ubuntu-latest
-
-    steps:
+      - name: Checkout PR and Master Branch
       - uses: actions/checkout@v2
         with:
           path: pr
@@ -46,6 +35,7 @@ jobs:
         with:
           ref: master
           path: master
+
       - name: Run Benchmark on Master (baseline)
         run: cd master && pytest tests/integration_tests/test_speed.py --benchmark-only --benchmark-json=benchmark.json
       - name: Run Benchmark on PR

--- a/.github/workflows/perf-regression.yml
+++ b/.github/workflows/perf-regression.yml
@@ -28,7 +28,7 @@ jobs:
           pip install -e catanatron_experimental
 
       - name: Checkout PR and Master Branch
-      - uses: actions/checkout@v2
+        uses: actions/checkout@v2
         with:
           path: pr
       - uses: actions/checkout@v2

--- a/.github/workflows/perf-regression.yml
+++ b/.github/workflows/perf-regression.yml
@@ -1,0 +1,71 @@
+
+# This workflow will compare the current branch with the main branch and evaluate for performance differences.
+
+name: Performance Regression Test
+
+on:
+  pull_request:
+    branches: master
+
+jobs:
+  build-docker:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build the Server Docker image
+        run: docker build . -f Dockerfile.web -t bcollazo/catanatron-server:latest
+
+  build-python:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r dev-requirements.txt
+          pip install -e catanatron_core
+          pip install -e catanatron_gym
+          pip install -e catanatron_server
+          pip install -e catanatron_experimental
+
+  benchmark-performance:
+    name: Time Benchmark
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          path: pr
+      - uses: actions/checkout@v2
+        with:
+          ref: master
+          path: master
+      - name: Run Benchmark on Master (baseline)
+        run: cd master && pytest tests/integration_tests/test_speed.py --benchmark-only --benchmark-json=benchmark.json
+      - name: Run Benchmark on PR
+        run: cd pr && pytest tests/integration_tests/test_speed.py --benchmark-only --benchmark-json=benchmark.json
+
+      - name: Compare Results
+        uses: openpgpjs/github-action-pull-request-benchmark@v1
+        with:
+          tool: 'pytest'
+          pr-benchmark-file-path: pr/benchmark.json
+          base-benchmark-file-path: master/benchmark.json
+          alert-threshold: '130%'
+          # Workflow will fail if `fail-threshold` is exceeded
+          fail-on-alert: true
+          fail-threshold: '150%'
+
+
+
+
+
+
+
+

--- a/catanatron_experimental/catanatron_experimental/machine_learning/players/minimax.py
+++ b/catanatron_experimental/catanatron_experimental/machine_learning/players/minimax.py
@@ -74,6 +74,8 @@ class AlphaBetaPlayer(Player):
         # if game.state.num_turns > 10:
         #     render_debug_tree(node)
         #     breakpoint()
+        if result[0] is None:
+            return playable_actions[0]
         return result[0]
 
     def __repr__(self) -> str:

--- a/tests/integration_tests/test_speed.py
+++ b/tests/integration_tests/test_speed.py
@@ -1,9 +1,12 @@
 import json
 
-from catanatron.json import GameEncoder
 from catanatron.game import Game
-from catanatron.models.player import SimplePlayer, Color
+from catanatron.json import GameEncoder
+from catanatron.models.player import Color, SimplePlayer, RandomPlayer
+from catanatron.players.weighted_random import WeightedRandomPlayer
 from catanatron_gym.features import create_sample
+
+from catanatron_experimental.machine_learning.players.minimax import AlphaBetaPlayer, SameTurnAlphaBetaPlayer
 
 
 # Things to benchmark. create_sample(), game.play() (random game), .to_json(), .copy()
@@ -47,3 +50,68 @@ def test_create_sample_speed(benchmark):
     sample = benchmark(create_sample, game, players[1].color)
     assert isinstance(sample, dict)
     assert len(sample) > 0
+
+
+# Benchmarking individual player speeds
+def test_simpleplayer_speed(benchmark):
+    players = [
+        SimplePlayer(Color.RED),
+        SimplePlayer(Color.BLUE),
+        SimplePlayer(Color.WHITE),
+        SimplePlayer(Color.ORANGE),
+    ]
+    game = Game(players)
+    def _play_game(game):
+        for _ in range(100):
+            game.play_tick()
+        return game
+
+    result = benchmark(_play_game, game)
+
+
+def test_weightedrandom_speed(benchmark):
+    players = [
+        RandomPlayer(Color.RED),
+        RandomPlayer(Color.BLUE),
+        RandomPlayer(Color.WHITE),
+        WeightedRandomPlayer(Color.ORANGE),
+    ]
+    game = Game(players)
+    def _play_game(game):
+        for _ in range(100):
+            game.play_tick()
+        return game
+
+    result = benchmark(_play_game, game)
+
+
+def test_alphabeta_speed(benchmark):
+    players = [
+        RandomPlayer(Color.RED),
+        RandomPlayer(Color.BLUE),
+        RandomPlayer(Color.WHITE),
+        AlphaBetaPlayer(Color.ORANGE),
+    ]
+    game = Game(players)
+    def _play_game(game):
+        for _ in range(100):
+            game.play_tick()
+        return game
+
+    result = benchmark(_play_game, game)
+
+
+def test_same_turn_alphabeta_speed(benchmark):
+    players = [
+        RandomPlayer(Color.RED),
+        RandomPlayer(Color.BLUE),
+        RandomPlayer(Color.WHITE),
+        SameTurnAlphaBetaPlayer(Color.ORANGE),
+    ]
+    game = Game(players)
+    def _play_game(game):
+        for _ in range(100):
+            game.play_tick()
+        return game
+
+    result = benchmark(_play_game, game)

--- a/tests/integration_tests/test_speed.py
+++ b/tests/integration_tests/test_speed.py
@@ -5,8 +5,9 @@ from catanatron.json import GameEncoder
 from catanatron.models.player import Color, SimplePlayer, RandomPlayer
 from catanatron.players.weighted_random import WeightedRandomPlayer
 from catanatron_gym.features import create_sample
-
 from catanatron_experimental.machine_learning.players.minimax import AlphaBetaPlayer, SameTurnAlphaBetaPlayer
+
+RANDOM_SEED = 0
 
 
 # Things to benchmark. create_sample(), game.play() (random game), .to_json(), .copy()
@@ -17,7 +18,7 @@ def test_to_json_speed(benchmark):
         SimplePlayer(Color.ORANGE),
         SimplePlayer(Color.WHITE),
     ]
-    game = Game(players)
+    game = Game(players, seed=RANDOM_SEED)
 
     result = benchmark(json.dumps, game, cls=GameEncoder)
     assert isinstance(result, str)
@@ -30,7 +31,7 @@ def test_copy_speed(benchmark):
         SimplePlayer(Color.ORANGE),
         SimplePlayer(Color.WHITE),
     ]
-    game = Game(players)
+    game = Game(players, seed=RANDOM_SEED)
 
     result = benchmark(game.copy)
     assert result.seed == game.seed
@@ -43,7 +44,7 @@ def test_create_sample_speed(benchmark):
         SimplePlayer(Color.WHITE),
         SimplePlayer(Color.ORANGE),
     ]
-    game = Game(players)
+    game = Game(players, seed=RANDOM_SEED)
     for _ in range(30):
         game.play_tick()
 
@@ -60,7 +61,7 @@ def test_simpleplayer_speed(benchmark):
         SimplePlayer(Color.WHITE),
         SimplePlayer(Color.ORANGE),
     ]
-    game = Game(players)
+    game = Game(players, seed=RANDOM_SEED)
     def _play_game(game):
         for _ in range(100):
             game.play_tick()
@@ -76,7 +77,7 @@ def test_weightedrandom_speed(benchmark):
         RandomPlayer(Color.WHITE),
         WeightedRandomPlayer(Color.ORANGE),
     ]
-    game = Game(players)
+    game = Game(players, seed=RANDOM_SEED)
     def _play_game(game):
         for _ in range(100):
             game.play_tick()
@@ -92,7 +93,7 @@ def test_alphabeta_speed(benchmark):
         RandomPlayer(Color.WHITE),
         AlphaBetaPlayer(Color.ORANGE),
     ]
-    game = Game(players)
+    game = Game(players, seed=RANDOM_SEED)
     def _play_game(game):
         for _ in range(100):
             game.play_tick()
@@ -108,7 +109,7 @@ def test_same_turn_alphabeta_speed(benchmark):
         RandomPlayer(Color.WHITE),
         SameTurnAlphaBetaPlayer(Color.ORANGE),
     ]
-    game = Game(players)
+    game = Game(players, seed=RANDOM_SEED)
     def _play_game(game):
         for _ in range(100):
             game.play_tick()


### PR DESCRIPTION
Added to the integration tests a few benchmarks consisting  of 100 ticks of games of 3 Random Players vs WeightedRandomPlayer, AlphaBetaPlayer, and SameTurnAlphaBetaPlayer. Also one of just 4 SimplePlayers.

These benchmarks are run with the new workflow and compare the results with the master branch. Should be helpful too quickly show if a PR is introducing a regression in terms of performance.

Not 100% convinced the workflow works as intended, but at least it dumps enough useful info to manually see if the PR is introducing a regression. The benefits here are to introduce a consistent and easy way to test performance and catch regressions for both the game logic and specialized player logic.

Also found a bug in AlphaBeta where it would sometimes return None as an action. Might be worth splitting this as a separate commit/pr and investigate further.

![Screenshot 2023-01-15 at 1 53 42 AM](https://user-images.githubusercontent.com/7763689/212525448-5502b2b7-af8f-42f2-b64e-c3a6eadbdbab.png)


