### PR TITLE
honor seed=0 by checking if seed is none instead of using or operator

### DIFF
--- a/catanatron_core/catanatron/game.py
+++ b/catanatron_core/catanatron/game.py
@@ -106,7 +106,7 @@ class Game:
             initialize (bool, optional): Whether to initialize. Defaults to True.
         """
         if initialize:
-            self.seed = seed or random.randrange(sys.maxsize)
+            self.seed = seed if seed is not None else random.randrange(sys.maxsize)
             random.seed(self.seed)
 
             self.id = str(uuid.uuid4())


### PR DESCRIPTION
This is probably why seed wasn't being honored, since `0 or random` will be random everytime, its better to check explicitly for None.