### PR TITLE
Fix github actions: build-python, build-gym.

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -65,6 +65,8 @@ jobs:
           python-version: 3.8
       - name: Install dependencies
         run: |
+          python -m pip install wheel
+          python -m pip install --upgrade pip
           pip install -e catanatron_core
           pip install -e catanatron_gym
       - name: Inline test

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -33,6 +33,7 @@ jobs:
           python-version: 3.8
       - name: Install dependencies
         run: |
+          python -m pip install wheel
           python -m pip install --upgrade pip
           pip install -r all-requirements.txt
       - name: Lint with black


### PR DESCRIPTION
I noticed that the current build-python, build-gym actions were broken, however, the code works just fine if you try it locally. It's a build step issue.

The issue seems related to the dependency install step and similar to this [one](https://github.com/pypa/pip/issues/11972#issuecomment-1511072994). Where pip changes the default way it builds packages when the `wheel` package is not installed. To mitigate one can simply ensure that the `wheel` package` is installed.

I'm not too clear on why the build step requires the `wheel` package.. maybe a change to the setup.py file is needed.