### PR TITLE
Minor changes for readability.

### DIFF
--- a/catanatron_core/catanatron/models/board.py
+++ b/catanatron_core/catanatron/models/board.py
@@ -252,12 +252,12 @@ class Board:
 
         expandable = set()
 
-        # non-enemy-nodes in your connected components
+        # All nodes for this color.
+        # TODO(tonypr): Explore caching for 'expandable_nodes'?
+        # The 'expandable_nodes' set should only increase in size monotonically I think.
+        # We can take advantage of that.
         expandable_nodes = set()
-        for node_set in self.connected_components[color]:
-            for node in node_set:
-                if not self.is_enemy_node(node, color):
-                    expandable_nodes.add(node)
+        expandable_nodes = expandable_nodes.union(*self.connected_components[color])
 
         candidate_edges = self.buildable_subgraph.edges(expandable_nodes)
         for edge in candidate_edges:

--- a/catanatron_core/catanatron/models/board.py
+++ b/catanatron_core/catanatron/models/board.py
@@ -362,7 +362,7 @@ def longest_acyclic_path(board: Board, node_set: Set[int], color: Color):
                     continue  # enemy-owned, cant use this to navigate.
                 edge = tuple(sorted((node, neighbor_node)))
                 if edge not in path_thus_far:
-                    agenda.insert(0, (neighbor_node, path_thus_far + [edge]))
+                    agenda.append((neighbor_node, path_thus_far + [edge]))
                     able_to_navigate = True
 
             if not able_to_navigate:  # then it is leaf node

--- a/catanatron_core/catanatron/models/board.py
+++ b/catanatron_core/catanatron/models/board.py
@@ -338,7 +338,11 @@ class Board:
         return node_color is not None and node_color != color
 
     def is_enemy_road(self, edge, color):
-        return self.get_edge_color(edge) != color
+        edge_color = self.get_edge_color(edge)
+        return edge_color is not None and self.get_edge_color(edge) != color
+
+    def is_friendly_road(self, edge, color):
+        return self.get_edge_color(edge) == color
 
 
 def longest_acyclic_path(board: Board, node_set: Set[int], color: Color):
@@ -354,9 +358,11 @@ def longest_acyclic_path(board: Board, node_set: Set[int], color: Color):
             for neighbor_node in STATIC_GRAPH.neighbors(node):
                 edge = tuple(sorted((node, neighbor_node)))
 
-                if board.is_enemy_road(edge, color):
+                # Must travel on a friendly road.
+                if not board.is_friendly_road(edge, color):
                     continue
 
+                # Can't expand past an enemy node.
                 if board.is_enemy_node(neighbor_node, color):
                     continue
 

--- a/catanatron_core/catanatron/models/board.py
+++ b/catanatron_core/catanatron/models/board.py
@@ -338,8 +338,7 @@ class Board:
         return node_color is not None and node_color != color
 
     def is_enemy_road(self, edge, color):
-        edge_color = self.get_edge_color(edge)
-        return edge_color is not None and edge_color != color
+        return self.get_edge_color(edge) != color
 
 
 def longest_acyclic_path(board: Board, node_set: Set[int], color: Color):
@@ -353,14 +352,14 @@ def longest_acyclic_path(board: Board, node_set: Set[int], color: Color):
 
             able_to_navigate = False
             for neighbor_node in STATIC_GRAPH.neighbors(node):
-                edge_color = board.get_edge_color((node, neighbor_node))
-                if edge_color != color:
+                edge = tuple(sorted((node, neighbor_node)))
+
+                if board.is_enemy_road(edge, color):
                     continue
 
-                neighbor_color = board.get_node_color(neighbor_node)
-                if neighbor_color is not None and neighbor_color != color:
-                    continue  # enemy-owned, cant use this to navigate.
-                edge = tuple(sorted((node, neighbor_node)))
+                if board.is_enemy_node(neighbor_node, color):
+                    continue
+
                 if edge not in path_thus_far:
                     agenda.append((neighbor_node, path_thus_far + [edge]))
                     able_to_navigate = True

--- a/catanatron_core/catanatron/models/board.py
+++ b/catanatron_core/catanatron/models/board.py
@@ -264,9 +264,8 @@ class Board:
             if self.get_edge_color(edge) is None:
                 expandable.add(tuple(sorted(edge)))
 
-        buildable_edges_list = list(expandable)
-        self.buildable_edges_cache[color] = buildable_edges_list
-        return buildable_edges_list
+        self.buildable_edges_cache[color] = list(expandable)
+        return self.buildable_edges_cache[color]
 
     def get_player_port_resources(self, color):
         """Yields resources (None for 3:1) of ports owned by color"""

--- a/catanatron_core/catanatron/models/board.py
+++ b/catanatron_core/catanatron/models/board.py
@@ -198,12 +198,10 @@ class Board:
         a_index = self._get_connected_component_index(a, color)
         b_index = self._get_connected_component_index(b, color)
 
-        if a_index is None and b_index is not None and not self.is_enemy_node(a, color):
+        if a_index is None and not self.is_enemy_node(a, color):
             self.connected_components[color][b_index].add(a)
             component = self.connected_components[color][b_index]
-        elif (
-            a_index is not None and b_index is None and not self.is_enemy_node(b, color)
-        ):
+        elif b_index is None and not self.is_enemy_node(b, color):
             self.connected_components[color][a_index].add(b)
             component = self.connected_components[color][a_index]
         elif a_index is not None and b_index is not None and a_index != b_index:

--- a/catanatron_core/catanatron/models/board.py
+++ b/catanatron_core/catanatron/models/board.py
@@ -123,9 +123,9 @@ class Board:
                     a = [n for n in edges[0] if n != node_id].pop()
                     c = [n for n in edges[1] if n != node_id].pop()
 
-                    # do bfs from a adding all encountered nodes
-                    a_nodeset = self.bfs_walk(a, edge_color)
-                    c_nodeset = self.bfs_walk(c, edge_color)
+                    # do dfs from a adding all encountered nodes
+                    a_nodeset = self.dfs_walk(a, edge_color)
+                    c_nodeset = self.dfs_walk(c, edge_color)
 
                     # split this components on here.
                     b_index = self._get_connected_component_index(node_id, edge_color)
@@ -152,7 +152,7 @@ class Board:
         self.player_port_resources_cache = {}  # Reset port resources
         return previous_road_color, self.road_color, self.road_lengths
 
-    def bfs_walk(self, node_id, color):
+    def dfs_walk(self, node_id, color):
         """Generates set of nodes that are "connected" to given node.
 
         Args:
@@ -197,6 +197,7 @@ class Board:
         a, b = edge
         a_index = self._get_connected_component_index(a, color)
         b_index = self._get_connected_component_index(b, color)
+
         if a_index is None and b_index is not None and not self.is_enemy_node(a, color):
             self.connected_components[color][b_index].add(a)
             component = self.connected_components[color][b_index]


### PR DESCRIPTION
Some minor style/readability improvements:
- Simplifies the `expandable_nodes` computation. Nodes in the connected component should only be from that color, so we can remove the existing color check.
- We can simplify `is_enemy_road` by not adding the extra `is not None` check as it's not needed. It shouldn't be needed for `is_enemy_node` either.. but that seemed to fail for some reason I didn't get into.
- Changes the `longest_acyclic_path` method to prefer `.append` in the DFS search for performance as .insert(0) shifts the whole list. Would have to use a queue otherwise but it's not necessary.
- Also simplifies the `longest_acyclic_path` method by using helper methods for friendly/enemy roads/nodes.

Tested with:
`coverage run --source=catanatron -m pytest tests/`