### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,7 @@ services:
     ports:
       - 5000:5000
     stdin_open: true
+    restart: always
     volumes:
       - .:/app
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   db:
     image: postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,6 @@ services:
       timeout: 5s
       retries: 5
   server:
-    image: bcollazo/catanatron-server:latest
     build:
       context: .
       dockerfile: Dockerfile.web
@@ -30,7 +29,6 @@ services:
       db:
         condition: service_healthy
   react-ui:
-    image: bcollazo/catanatron-react-ui:latest
     build: ./ui
     ports:
       - 3000:3000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,11 @@ services:
       - POSTGRES_DB=catanatron_db
     ports:
       - 5432:5432
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -d postgresql://catanatron:victorypoint@db:5432/catanatron_db"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
   server:
     image: bcollazo/catanatron-server:latest
     build:
@@ -21,7 +26,8 @@ services:
     volumes:
       - .:/app
     depends_on:
-      - "db"
+      db:
+        condition: service_healthy
   react-ui:
     image: bcollazo/catanatron-react-ui:latest
     build: ./ui


### PR DESCRIPTION
## Description
Several improvements, motivated by https://github.com/bcollazo/catanatron/issues/273. This should fix https://github.com/bcollazo/catanatron/issues/273.

## Changes
- Sometimes the server would come up before the database, and so not connect properly. Made it so that docker-compose doesn't bring up the server until the database is "healthy" and accepting connection, as well as made the server be restarted if it fails.
- Removed the version clause which is outdated in docker-compose.
- Removed the `image:` to avoid docker-compose using potentially outdated images. Went with this approach seems it seems easier on maintenance (we just have to worry to have latest `master` buildable). I'll probably delete / update the docker images later.

## Screenshots
<img width="1461" alt="Screenshot 2024-07-04 at 7 28 20 AM" src="https://github.com/bcollazo/catanatron/assets/982382/a451d0be-463d-4fc4-b2e7-a5611fa21b8e">
<img width="1000" alt="Screenshot 2024-07-04 at 7 23 52 AM" src="https://github.com/bcollazo/catanatron/assets/982382/7ffae943-81ca-4548-8707-093773dac955">
<img width="1341" alt="Screenshot 2024-07-04 at 7 29 44 AM" src="https://github.com/bcollazo/catanatron/assets/982382/6acbcd76-2466-418c-a971-2ee18b5711a5">
