### PR TITLE
Add States Navigator to UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,4 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+game_states_pickle/

--- a/README.md
+++ b/README.md
@@ -95,11 +95,11 @@ To use, ensure you have [Docker Compose](https://docs.docker.com/compose/install
 docker-compose up
 ```
 
-You can now use the `--db` flag to make the catanatron-play simulator save
-the game in the database for inspection via the web server.
+You can now use the `--pickle` flag to make the catanatron-play simulator save
+the game as local pickle files for inspection via the web server.
 
 ```
-catanatron-play --players=W,W,W,W --db --num=1
+catanatron-play --players=W,W,W,W --pickle --num=1
 ```
 
 NOTE: A great contribution would be to make the Web UI allow to step forwards and backwards in a game to inspect it (ala chess.com).
@@ -159,7 +159,7 @@ open_link(game)  # opens game in browser
 
 The code is divided in the following 5 components (folders):
 
-- **catanatron**: A pure python implementation of the game logic. Uses `networkx` for fast graph operations. Is pip-installable (see `setup.py`) and can be used as a Python package. See the documentation for the package here: https://catanatron.readthedocs.io/.
+- **catanatron**: A pure python implementation of the game logic. Uses `networkx` for fast graph operations. Is pip-installable (see `setup.py`) and can be used as a Python package. See the documentation for the package here: <https://catanatron.readthedocs.io/>.
 
 - **catanatron_server**: Contains a Flask web server in order to serve
   game states from a database to a Web UI. The idea of using a database, is to ease watching games played in a different process. It defaults to using an ephemeral in-memory sqlite database. Also pip-installable (not publised in PyPi however).
@@ -168,7 +168,7 @@ The code is divided in the following 5 components (folders):
 
 - **catantron_experimental**: A collection of unorganized scripts with contain many failed attempts at finding the best possible bot. Its ok to break these scripts. Its pip-installable. Exposes a `catanatron-play` command-line script that can be used to play games in bulk, create machine learning datasets of games, and more!
 
-- **ui**: A React web UI to render games. This is helpful for debugging the core implementation. We decided to use the browser as a randering engine (as opposed to the terminal or a desktop GUI) because of HTML/CSS's ubiquitousness and the ability to use modern animation libraries in the future (https://www.framer.com/motion/ or https://www.react-spring.io/).
+- **ui**: A React web UI to render games. This is helpful for debugging the core implementation. We decided to use the browser as a randering engine (as opposed to the terminal or a desktop GUI) because of HTML/CSS's ubiquitousness and the ability to use modern animation libraries in the future (<https://www.framer.com/motion/> or <https://www.react-spring.io/>).
 
 ## AI Bots Leaderboard
 
@@ -264,7 +264,7 @@ docker run -it -p 5000:5000 bcollazo/catanatron-server
 
 ### PostgreSQL Database
 
-Make sure you have `docker-compose` installed (https://docs.docker.com/compose/install/).
+Make sure you have `docker-compose` installed (<https://docs.docker.com/compose/install/>).
 
 ```
 docker-compose up

--- a/catanatron_core/catanatron/game.py
+++ b/catanatron_core/catanatron/game.py
@@ -112,6 +112,7 @@ class Game:
             self.id = str(uuid.uuid4())
             self.vps_to_win = vps_to_win
             self.state = State(players, catan_map, discard_limit=discard_limit)
+            self.state_index = 0
 
     def play(self, accumulators=[], decide_fn=None):
         """Executes game until a player wins or exceeded TURNS_LIMIT.
@@ -130,6 +131,7 @@ class Game:
             accumulator.before(self)
         while self.winning_color() is None and self.state.num_turns < TURNS_LIMIT:
             self.play_tick(decide_fn=decide_fn, accumulators=accumulators)
+            self.state_index += 1
         for accumulator in accumulators:
             accumulator.after(self)
         return self.winning_color()

--- a/catanatron_experimental/catanatron_experimental/cli/accumulators.py
+++ b/catanatron_experimental/catanatron_experimental/cli/accumulators.py
@@ -146,7 +146,6 @@ class PickleAccumulator(GameAccumulator):
 
     def after(self, game):
         serialize_game_state(game, game.state_index)
-        save_game_metadata(game)
         self.link = f"http://localhost:3000/games/{game.id}/states/{game.state_index}"
 
 

--- a/catanatron_server/catanatron_server/__init__.py
+++ b/catanatron_server/catanatron_server/__init__.py
@@ -10,24 +10,13 @@ def create_app(test_config=None):
     CORS(app)
 
     # ===== Load base configuration
-    database_url = os.environ.get("DATABASE_URL", "sqlite:///:memory:")
-    if database_url.startswith("postgres://"):
-        database_url = database_url.replace("postgres://", "postgresql://", 1)
     secret_key = os.environ.get("SECRET_KEY", "dev")
     app.config.from_mapping(
         SECRET_KEY=secret_key,
-        SQLALCHEMY_DATABASE_URI=database_url,
         SQLALCHEMY_TRACK_MODIFICATIONS=False,
     )
     if test_config is not None:
         app.config.update(test_config)
-
-    # ===== Initialize Database
-    from catanatron_server.models import db
-
-    with app.app_context():
-        db.init_app(app)
-        db.create_all()
 
     # ===== Initialize Routes
     from . import api

--- a/catanatron_server/catanatron_server/api.py
+++ b/catanatron_server/catanatron_server/api.py
@@ -41,7 +41,7 @@ def post_game_endpoint():
         "state_index": game.state_index
         })
 
-
+# get game state by uuid and state_index
 @bp.route("/games/<string:game_id>/states/<string:state_index>", methods=("GET",))
 def get_game_endpoint(game_id, state_index):
     state_index = None if state_index == "latest" else int(state_index)
@@ -59,7 +59,7 @@ def get_game_endpoint(game_id, state_index):
 @bp.route("/games/<string:game_id>/states/<string:state_index>/actions", methods=["POST"])
 def post_action_endpoint(game_id, state_index):
     state_index = None if state_index == "latest" else int(state_index)
-    
+
     game = load_game_state(game_id, state_index)
     if game is None:
         abort(404, description="Resource not found")
@@ -149,21 +149,6 @@ def get_info():
         "games_uuid": games_uuid
         })
 
-
-# get game state by uuid and state_index
-@bp.route(
-    "/games/<string:game_id>/states/<int:state_index>/info", methods=["GET"]
-)
-def get_one_game_state(game_id, state_index):
-    game_state = load_game_state(game_id, state_index)
-    if game_state is None:
-        abort(404, description="Resource not found")
-
-    return Response(
-        response=json.dumps(game_state, cls=GameEncoder),
-        status=200,
-        mimetype="application/json",
-    )
 
 # @app.route("/games/<string:game_id>/value-function", methods=["GET"])
 # def get_game_value_function(game_id):

--- a/catanatron_server/catanatron_server/api.py
+++ b/catanatron_server/catanatron_server/api.py
@@ -58,6 +58,8 @@ def get_game_endpoint(game_id, state_index):
 
 @bp.route("/games/<string:game_id>/states/<string:state_index>/actions", methods=["POST"])
 def post_action_endpoint(game_id, state_index):
+    state_index = None if state_index == "latest" else int(state_index)
+    
     game = load_game_state(game_id, state_index)
     if game is None:
         abort(404, description="Resource not found")

--- a/catanatron_server/catanatron_server/api.py
+++ b/catanatron_server/catanatron_server/api.py
@@ -2,13 +2,17 @@ import json
 
 from flask import Response, Blueprint, jsonify, abort, request
 
-from catanatron_server.models import upsert_game_state, get_game_state
+from catanatron_server.models import get_game_metadata, get_games_info, serialize_game_state, load_game_state
 from catanatron.json import GameEncoder, action_from_json
 from catanatron.models.player import Color, RandomPlayer
 from catanatron.game import Game
 from catanatron_experimental.machine_learning.players.value import ValueFunctionPlayer
 from catanatron_experimental.machine_learning.players.minimax import AlphaBetaPlayer
-
+from catanatron_gym.features import (
+    create_sample,
+    # create_sample_vector,
+    # get_feature_ordering,
+)
 
 bp = Blueprint("api", __name__, url_prefix="/api")
 
@@ -30,14 +34,18 @@ def post_game_endpoint():
     players = list(map(player_factory, zip(player_keys, Color)))
 
     game = Game(players=players)
-    upsert_game_state(game)
-    return jsonify({"game_id": game.id})
+    serialize_game_state(game, game.state_index)
+    
+    return jsonify({
+        "game_id": game.id,
+        "state_index": game.state_index
+        })
 
 
 @bp.route("/games/<string:game_id>/states/<string:state_index>", methods=("GET",))
 def get_game_endpoint(game_id, state_index):
     state_index = None if state_index == "latest" else int(state_index)
-    game = get_game_state(game_id, state_index)
+    game = load_game_state(game_id, state_index)
     if game is None:
         abort(404, description="Resource not found")
 
@@ -48,9 +56,9 @@ def get_game_endpoint(game_id, state_index):
     )
 
 
-@bp.route("/games/<string:game_id>/actions", methods=["POST"])
-def post_action_endpoint(game_id):
-    game = get_game_state(game_id)
+@bp.route("/games/<string:game_id>/states/<string:state_index>/actions", methods=["POST"])
+def post_action_endpoint(game_id, state_index):
+    game = load_game_state(game_id, state_index)
     if game is None:
         abort(404, description="Resource not found")
 
@@ -65,11 +73,11 @@ def post_action_endpoint(game_id):
     body_is_empty = (not request.data) or request.json is None
     if game.state.current_player().is_bot or body_is_empty:
         game.play_tick()
-        upsert_game_state(game)
+        serialize_game_state(game, game.state_index)
     else:
         action = action_from_json(request.json)
         game.execute(action)
-        upsert_game_state(game)
+        serialize_game_state(game, game.state_index)
 
     return Response(
         response=json.dumps(game, cls=GameEncoder),
@@ -96,16 +104,64 @@ def stress_test_endpoint():
 
 
 # ===== Debugging Routes
-# @app.route(
-#     "/games/<string:game_id>/players/<int:player_index>/features", methods=["GET"]
-# )
-# def get_game_feature_vector(game_id, player_index):
-#     game = get_game_state(game_id)
-#     if game is None:
-#         abort(404, description="Resource not found")
+@bp.route(
+    "/games/<string:game_id>/players/<int:player_index>/features", methods=["GET"]
+)
+def get_game_feature_vector(game_id, player_index):
+    # game = get_game(game_id)
+    game = load_game_state(game_id, None)
+    if game is None:
+        abort(404, description="Resource not found")
 
-#     return create_sample(game, game.state.colors[player_index])
+    return create_sample(game, game.state.colors[player_index])
 
+
+# get game info
+@bp.route(
+    "/games/<string:game_id>/info", methods=["GET"]
+)
+def get_game_info(game_id):
+    game_metadata = get_game_metadata(game_id)
+
+    if game_metadata is None:
+        abort(404, description="Metadata not found")
+
+    return jsonify({
+        "game_states_count": game_metadata["game_states_count"],
+        "winner": game_metadata["winner"],
+        "players": game_metadata["players"]
+    })
+
+# get general info
+@bp.route(
+    "/info", methods=["GET"]
+)
+def get_info():
+    game_count, games_uuid = get_games_info()
+
+    # games_uuid = [str(game_id[0]) for game_id in games_uuid] # convert to string
+
+    return jsonify({
+        # "game_states_count": game_states_count, 
+        "games_count": game_count, 
+        "games_uuid": games_uuid
+        })
+
+
+# get game state by uuid and state_index
+@bp.route(
+    "/games/<string:game_id>/states/<int:state_index>/info", methods=["GET"]
+)
+def get_one_game_state(game_id, state_index):
+    game_state = load_game_state(game_id, state_index)
+    if game_state is None:
+        abort(404, description="Resource not found")
+
+    return Response(
+        response=json.dumps(game_state, cls=GameEncoder),
+        status=200,
+        mimetype="application/json",
+    )
 
 # @app.route("/games/<string:game_id>/value-function", methods=["GET"])
 # def get_game_value_function(game_id):

--- a/catanatron_server/catanatron_server/models.py
+++ b/catanatron_server/catanatron_server/models.py
@@ -13,18 +13,6 @@ def get_games_info():
 
     return game_count, games_uuid
 
-# serialize and store game state using pickle
-def serialize_game_state(game, state_index):
-    pickle_game_dir = f"{pickle_game_states_dir}/{game.id}"
-    
-    # create pickle directory if it doesn't exist
-    if not os.path.exists(pickle_game_dir):
-        os.makedirs(pickle_game_dir)
-
-    # save pickle data to file
-    with open(f"{pickle_game_dir}/{state_index}.pickle", "wb") as f:
-        pickle.dump(game, f)
-
 
 def save_game_metadata(game):
     pickle_game_dir = f"{pickle_game_states_dir}/{game.id}"
@@ -42,6 +30,22 @@ def save_game_metadata(game):
             "game_states_count": game.state_index + 1
         }
         json.dump(metadata, f)
+
+
+# serialize and store game state using pickle
+def serialize_game_state(game, state_index):
+    pickle_game_dir = f"{pickle_game_states_dir}/{game.id}"
+    
+    # create pickle directory if it doesn't exist
+    if not os.path.exists(pickle_game_dir):
+        os.makedirs(pickle_game_dir)
+
+    # save pickle data to file
+    with open(f"{pickle_game_dir}/{state_index}.pickle", "wb") as f:
+        pickle.dump(game, f)
+    
+    # update metadata
+    save_game_metadata(game)
 
 
 # retrieve all game states of a game

--- a/catanatron_server/catanatron_server/models.py
+++ b/catanatron_server/catanatron_server/models.py
@@ -1,87 +1,83 @@
 import os
 import json
 import pickle
-from contextlib import contextmanager
 
-from sqlalchemy import MetaData, Column, Integer, String, LargeBinary, create_engine
-from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import Session
-from flask_sqlalchemy import SQLAlchemy
+pickle_game_states_dir = "game_states_pickle"
 
-from catanatron.json import GameEncoder
+# retrieve uuid of all games
+def get_games_info():
+    # list all folders in game_states_pickle
+    games_uuid = [name for name in os.listdir(pickle_game_states_dir) if os.path.isdir(os.path.join(pickle_game_states_dir, name))]
+    # count number of folders in game_states_pickle
+    game_count = len(games_uuid)
 
-# Using approach from: https://stackoverflow.com/questions/41004540/using-sqlalchemy-models-in-and-out-of-flask/41014157
-metadata = MetaData()
-Base = declarative_base(metadata=metadata)
+    return game_count, games_uuid
 
+# serialize and store game state using pickle
+def serialize_game_state(game, state_index):
+    pickle_game_dir = f"{pickle_game_states_dir}/{game.id}"
+    
+    # create pickle directory if it doesn't exist
+    if not os.path.exists(pickle_game_dir):
+        os.makedirs(pickle_game_dir)
 
-class GameState(Base):
-    __tablename__ = "game_states"
-
-    id = Column(Integer, primary_key=True)
-    uuid = Column(String(64), nullable=False)
-    state_index = Column(Integer, nullable=False)
-    state = Column(String, nullable=False)
-    pickle_data = Column(LargeBinary, nullable=False)
-
-    # TODO: unique uuid and state_index
-
-    @staticmethod
-    def from_game(game):
-        state = json.dumps(game, cls=GameEncoder)
-        pickle_data = pickle.dumps(game, pickle.HIGHEST_PROTOCOL)
-        return GameState(
-            uuid=game.id,
-            state_index=len(game.state.actions),
-            state=state,
-            pickle_data=pickle_data,
-        )
+    # save pickle data to file
+    with open(f"{pickle_game_dir}/{state_index}.pickle", "wb") as f:
+        pickle.dump(game, f)
 
 
-db = SQLAlchemy(metadata=metadata)
+def save_game_metadata(game):
+    pickle_game_dir = f"{pickle_game_states_dir}/{game.id}"
+
+    # create pickle directory if it doesn't exist
+    if not os.path.exists(pickle_game_dir):
+        os.makedirs(pickle_game_dir)
+
+    # save game metadata as a json file
+    with open(f"{pickle_game_dir}/metadata.json", "w") as f:
+        metadata = {
+            "id": game.id,
+            "players": [str(player.value) for player in game.state.colors],
+            "winner": str(game.winning_color()),
+            "game_states_count": game.state_index + 1
+        }
+        json.dump(metadata, f)
 
 
-@contextmanager
-def database_session():
-    """Can use like:
-    with database_session() as session:
-        game_states = session.query(GameState).all()
-    """
-    database_url = os.environ.get(
-        "DATABASE_URL",
-        "postgresql://catanatron:victorypoint@127.0.0.1:5432/catanatron_db",
-    )
-    engine = create_engine(database_url)
-    session = Session(engine)
-    try:
-        yield session
-    finally:
-        session.expunge_all()
-        session.close()
+# retrieve all game states of a game
+def get_game_metadata(game_id):
+    pickle_game_dir = f"{pickle_game_states_dir}/{game_id}"
+    
+    # check if game folder exists
+    if not os.path.exists(f"{pickle_game_dir}"):
+        return None
+
+    # read metadata.json file
+    with open(f"{pickle_game_dir}/metadata.json", "r") as f:
+        metadata = json.load(f)
+        return metadata
 
 
-def upsert_game_state(game, session_param=None):
-    game_state = GameState.from_game(game)
-    session = session_param or db.session
-    session.add(game_state)
-    session.commit()
-    return game_state
+# load game state from pickle file
+def load_game_state(game_id, state_index):
+    pickle_game_dir = f"{pickle_game_states_dir}/{game_id}"
 
+    # check if game folder exists
+    if not os.path.exists(f"{pickle_game_dir}"):
+        return None
 
-def get_game_state(game_id, state_index=None):
     if state_index is None:
-        result = (
-            db.session.query(GameState)
-            .filter_by(uuid=game_id)
-            .order_by(GameState.state_index.desc())
-            .first_or_404()
-        )
-    else:
-        result = (
-            db.session.query(GameState)
-            .filter_by(uuid=game_id, state_index=state_index)
-            .first_or_404()
-        )
-    db.session.commit()
-    game = pickle.loads(result.pickle_data)
+        metadata = get_game_metadata(game_id)
+        if metadata is None:
+            return None
+        game_states = metadata["game_states_count"]
+        state_index = game_states - 1
+
+    # check if file exists
+    if not os.path.exists(f"{pickle_game_dir}/{state_index}.pickle"):
+        return None
+
+    with open(f"{pickle_game_dir}/{state_index}.pickle", "rb") as f:
+        game = pickle.load(f)
+    
     return game

--- a/catanatron_server/catanatron_server/utils.py
+++ b/catanatron_server/catanatron_server/utils.py
@@ -1,21 +1,6 @@
 import webbrowser
 
-from catanatron_server.models import database_session, upsert_game_state
-
-
-def ensure_link(game):
-    """Upserts game to database per DATABASE_URL
-
-    Returns:
-        str: URL for inspecting state, per convention
-    """
-    with database_session() as session:
-        game_state = upsert_game_state(game, session)
-        url = f"http://localhost:3000/games/{game_state.uuid}/states/{game_state.state_index}"
-    return url
-
-
 def open_link(game):
-    """Upserts game to database and opens game in browser"""
-    link = ensure_link(game)
+    """opens game in browser"""
+    link = f"http://localhost:3000/games/{game.id}/states/latest"
     webbrowser.open(link)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,23 +1,9 @@
 services:
-  db:
-    image: postgres
-    environment:
-      - POSTGRES_USER=catanatron
-      - POSTGRES_PASSWORD=victorypoint
-      - POSTGRES_DB=catanatron_db
-    ports:
-      - 5432:5432
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready -d postgresql://catanatron:victorypoint@db:5432/catanatron_db"]
-      interval: 5s
-      timeout: 5s
-      retries: 5
   server:
     build:
       context: .
       dockerfile: Dockerfile.web
     environment:
-      - DATABASE_URL=postgresql://catanatron:victorypoint@db:5432/catanatron_db
       - PYTHONUNBUFFERED=1
     ports:
       - 5000:5000
@@ -25,9 +11,6 @@ services:
     restart: always
     volumes:
       - .:/app
-    depends_on:
-      db:
-        condition: service_healthy
   react-ui:
     build: ./ui
     ports:
@@ -36,3 +19,5 @@ services:
     volumes:
       - /app/node_modules
       - ./ui:/app
+    environment:
+      CHOKIDAR_USEPOLLING: "true" # Required for hot reloading in Windows

--- a/ui/src/pages/ActionsToolbar.js
+++ b/ui/src/pages/ActionsToolbar.js
@@ -19,6 +19,7 @@ import Popper from "@material-ui/core/Popper";
 import MenuList from "@material-ui/core/MenuList";
 import SimCardIcon from "@material-ui/icons/SimCard";
 import { useParams } from "react-router";
+import {useHistory} from "react-router-dom";
 
 import { ResourceCards } from "../components/PlayerStateBox";
 import Prompt, { humanizeTradeAction } from "../components/Prompt";
@@ -192,6 +193,8 @@ export default function ActionsToolbar({
   replayMode,
 }) {
   const { state, dispatch } = useContext(store);
+  const { gameId, stateIndex } = useParams();
+  const history = useHistory();
 
   const openLeftDrawer = useCallback(() => {
     dispatch({
@@ -204,6 +207,19 @@ export default function ActionsToolbar({
     state.gameState.current_color
   );
   const humanColor = getHumanColor(state.gameState);
+
+  const loadPreviousState = async () => {
+    const totalStates = parseInt(state.gameMetadata.game_states_count);
+    const previousState = stateIndex === "latest" ? totalStates - 1 : parseInt(stateIndex) - 1; 
+    // navigate to previous state using router
+    history.push(`/games/${gameId}/states/${previousState}`);
+  };
+
+  const loadNextState = async () => {
+    const nextState = stateIndex === "latest" ? 0 : parseInt(stateIndex) + 1; 
+    // navigate to next state using router
+    history.push(`/games/${gameId}/states/${nextState}`);
+  };
   return (
     <>
       <div className="state-summary">
@@ -238,6 +254,19 @@ export default function ActionsToolbar({
 
         {/* <Button onClick={zoomIn}>Zoom In</Button>
       <Button onClick={zoomOut}>Zoom Out</Button> */}
+
+      <Button className="State-button" disabled={parseInt(stateIndex) == 0} onClick={loadPreviousState}>
+        Previous
+      </Button>
+      <Button className="State-button" disabled={state.gameState.winning_color} onClick={loadNextState}>
+        Next
+      </Button>
+
+      {/* text input for selecting gamestates */}
+      <input type="number" className="State-picker" value={parseInt(stateIndex)} onChange={(e) => {
+        // navigate to stateIndex using router
+        history.push(`/games/${gameId}/states/${e.target.value}`);
+      }}/> out of {state.gameMetadata?.game_states_count - 1}
       </div>
     </>
   );

--- a/ui/src/pages/ActionsToolbar.js
+++ b/ui/src/pages/ActionsToolbar.js
@@ -255,7 +255,7 @@ export default function ActionsToolbar({
         {/* <Button onClick={zoomIn}>Zoom In</Button>
       <Button onClick={zoomOut}>Zoom Out</Button> */}
 
-      <Button className="State-button" disabled={parseInt(stateIndex) == 0} onClick={loadPreviousState}>
+      <Button className="State-button" disabled={parseInt(stateIndex) === 0} onClick={loadPreviousState}>
         Previous
       </Button>
       <Button className="State-button" disabled={state.gameState.winning_color} onClick={loadNextState}>

--- a/ui/src/pages/ActionsToolbar.scss
+++ b/ui/src/pages/ActionsToolbar.scss
@@ -53,4 +53,41 @@ $btn-height: 60px;
       margin: 0;
     }
   }
+
+  .State-button {
+    background-color: white;
+    color: black;
+    border-radius: 5px;
+    padding: 0 10px;
+    font-size: 14px;
+    font-weight: 500;
+    text-transform: capitalize;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    transition: background-color 0.3s;
+    width: 10px;
+    height: 40px;
+    &:hover {
+      background-color: gray;
+    }
+  }
+
+  /* Chrome, Safari, Edge, Opera */
+  input::-webkit-outer-spin-button,
+  input::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+  }
+
+  /* Firefox */
+  input[type=number] {
+    -moz-appearance: textfield;
+  }
+
+  .State-picker {
+    width: 40px;
+    height: 20px;
+  }
 }

--- a/ui/src/pages/GameScreen.js
+++ b/ui/src/pages/GameScreen.js
@@ -12,7 +12,7 @@ import "./GameScreen.scss";
 import LeftDrawer from "../components/LeftDrawer";
 import { store } from "../store";
 import ACTIONS from "../actions";
-import { getState, postAction } from "../utils/apiClient";
+import { getMetadata, getState, postAction } from "../utils/apiClient";
 import { dispatchSnackbar } from "../components/Snackbar";
 import { getHumanColor } from "../utils/stateUtils";
 
@@ -33,6 +33,11 @@ function GameScreen({ replayMode }) {
     (async () => {
       const gameState = await getState(gameId, stateIndex);
       dispatch({ type: ACTIONS.SET_GAME_STATE, data: gameState });
+    })();
+
+    (async () => {
+      const gameMetadata = await getMetadata(gameId);
+      dispatch({ type: ACTIONS.SET_GAME_METADATA, data: gameMetadata });
     })();
   }, [gameId, stateIndex, dispatch]);
 

--- a/ui/src/pages/Tile.js
+++ b/ui/src/pages/Tile.js
@@ -60,7 +60,7 @@ export default function Tile({ center, coordinate, tile, size }) {
     contents = (
       <NumberToken size={size}>
         <div>{tile.number}</div>
-        <div class="pips">{numberToPips(tile.number)}</div>
+        <div className="pips">{numberToPips(tile.number)}</div>
       </NumberToken>
     );
     resourceTile = {

--- a/ui/src/store.js
+++ b/ui/src/store.js
@@ -3,6 +3,7 @@ import ACTIONS from "./actions";
 
 const initialState = {
   gameState: null,
+  gameMetadata: null,
   // UI
   isBuildingRoad: false,
   isBuildingSettlement: false,
@@ -26,6 +27,8 @@ const StateProvider = ({ children }) => {
           isBuildingSettlement: false,
           isBuildingCity: false,
         };
+      case ACTIONS.SET_GAME_METADATA:
+        return { ...state, gameMetadata: action.data };
       case ACTIONS.SET_IS_BUILDING_ROAD:
         return { ...state, isBuildingRoad: true };
       case ACTIONS.SET_IS_BUILDING_SETTLEMENT:

--- a/ui/src/utils/apiClient.js
+++ b/ui/src/utils/apiClient.js
@@ -14,6 +14,11 @@ export async function getState(gameId, stateIndex = "latest") {
   return response.data;
 }
 
+export async function getMetadata(gameId) {
+  const response = await axios.get(`${API_URL}/api/games/${gameId}/info`);
+  return response.data;
+}
+
 /** action=undefined means bot action */
 export async function postAction(gameId, action = undefined) {
   const response = await axios.post(


### PR DESCRIPTION
For visiting old game states, it goes without saying that they need to be saved somewhere. However, saving the hundreds of game states of each game is very costly if we were to use a db, even with optimizations, and the db is unnecessary overhead in my opinion. Therefore:

1- **Changes to the flask server:**
* remove db service from docker-compose
* remove sql code and replace it with code for reading and writing pickle files
* add debugging apis: `/info`, `/games/<string:game_id>/info`

2- **Changes to main script:**
* use pickle files for storing game states instead of a database for reduced overhead
* rename `--db` cli option to `--pickle`
* rename `DatabaseAccumulator` to `PickleAccumulator`
* remove `StepDatabaseAccumulator`

3- **Changes to the react app:**
* add navigation buttons to ActionsToolbar for previous and next states
* add state counter and state picker

This is the best way of doing this in my opinion, but I would love to hear what you think.

closes #54.