### PR TITLE
Add pickle support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,4 @@ dmypy.json
 .pyre/
 
 /db-data
+game_states_pickle

--- a/catanatron_experimental/catanatron_experimental/cli/accumulators.py
+++ b/catanatron_experimental/catanatron_experimental/cli/accumulators.py
@@ -146,18 +146,25 @@ class DatabaseAccumulator(GameAccumulator):
 
 class PickleAccumulator(GameAccumulator):
     """Saves each game state to local pickle file"""
+
     def __init__(self, pickle_dir):
         self.pickle_dir = pickle_dir
 
     def before(self, game_before):
-        save_game_state_to_pickle(game_before, len(game_before.state.actions), self.pickle_dir)
+        save_game_state_to_pickle(
+            game_before, len(game_before.state.actions), self.pickle_dir
+        )
 
     def step(self, game_before_action, action):
-        save_game_state_to_pickle(game_before_action, len(game_before_action.state.actions), self.pickle_dir)
+        save_game_state_to_pickle(
+            game_before_action, len(game_before_action.state.actions), self.pickle_dir
+        )
 
     def after(self, game):
         save_game_state_to_pickle(game, len(game.state.actions), self.pickle_dir)
-        self.link = f"http://localhost:3000/games/{game.id}/states/{len(game.state.actions)}"
+        self.link = (
+            f"http://localhost:3000/games/{game.id}/states/{len(game.state.actions)}"
+        )
 
 
 class JsonDataAccumulator(GameAccumulator):

--- a/catanatron_server/catanatron_server/api.py
+++ b/catanatron_server/catanatron_server/api.py
@@ -2,8 +2,11 @@ import json
 
 from flask import Response, Blueprint, jsonify, abort, request
 
-from catanatron_server.utils import player_factory
-from catanatron_server.models import upsert_game_state, get_game_state
+from catanatron_server.utils import (
+    player_factory,
+    save_game_state_to_db,
+    get_game_state_from_db,
+)
 from catanatron.json import GameEncoder, action_from_json
 from catanatron.models.player import Color
 from catanatron.game import Game
@@ -19,14 +22,14 @@ def post_game_endpoint():
     players = list(map(player_factory, zip(player_keys, Color)))
 
     game = Game(players=players)
-    upsert_game_state(game)
+    save_game_state_to_db(game)
     return jsonify({"game_id": game.id})
 
 
 @bp.route("/games/<string:game_id>/states/<string:state_index>", methods=("GET",))
 def get_game_endpoint(game_id, state_index):
     state_index = None if state_index == "latest" else int(state_index)
-    game = get_game_state(game_id, state_index)
+    game = get_game_state_from_db(game_id, state_index)
     if game is None:
         abort(404, description="Resource not found")
 
@@ -39,7 +42,7 @@ def get_game_endpoint(game_id, state_index):
 
 @bp.route("/games/<string:game_id>/actions", methods=["POST"])
 def post_action_endpoint(game_id):
-    game = get_game_state(game_id)
+    game = get_game_state_from_db(game_id)
     if game is None:
         abort(404, description="Resource not found")
 
@@ -54,11 +57,11 @@ def post_action_endpoint(game_id):
     body_is_empty = (not request.data) or request.json is None
     if game.state.current_player().is_bot or body_is_empty:
         game.play_tick()
-        upsert_game_state(game)
+        save_game_state_to_db(game)
     else:
         action = action_from_json(request.json)
         game.execute(action)
-        upsert_game_state(game)
+        save_game_state_to_db(game)
 
     return Response(
         response=json.dumps(game, cls=GameEncoder),

--- a/catanatron_server/catanatron_server/api.py
+++ b/catanatron_server/catanatron_server/api.py
@@ -2,26 +2,15 @@ import json
 
 from flask import Response, Blueprint, jsonify, abort, request
 
+from catanatron_server.utils import player_factory
 from catanatron_server.models import upsert_game_state, get_game_state
 from catanatron.json import GameEncoder, action_from_json
-from catanatron.models.player import Color, RandomPlayer
+from catanatron.models.player import Color
 from catanatron.game import Game
-from catanatron_experimental.machine_learning.players.value import ValueFunctionPlayer
 from catanatron_experimental.machine_learning.players.minimax import AlphaBetaPlayer
 
 
 bp = Blueprint("api", __name__, url_prefix="/api")
-
-
-def player_factory(player_key):
-    if player_key[0] == "CATANATRON":
-        return AlphaBetaPlayer(player_key[1], 2, True)
-    elif player_key[0] == "RANDOM":
-        return RandomPlayer(player_key[1])
-    elif player_key[0] == "HUMAN":
-        return ValueFunctionPlayer(player_key[1], is_bot=False)
-    else:
-        raise ValueError("Invalid player key")
 
 
 @bp.route("/games", methods=("POST",))

--- a/catanatron_server/catanatron_server/models.py
+++ b/catanatron_server/catanatron_server/models.py
@@ -58,30 +58,3 @@ def database_session():
     finally:
         session.expunge_all()
         session.close()
-
-
-def upsert_game_state(game, session_param=None):
-    game_state = GameState.from_game(game)
-    session = session_param or db.session
-    session.add(game_state)
-    session.commit()
-    return game_state
-
-
-def get_game_state(game_id, state_index=None):
-    if state_index is None:
-        result = (
-            db.session.query(GameState)
-            .filter_by(uuid=game_id)
-            .order_by(GameState.state_index.desc())
-            .first_or_404()
-        )
-    else:
-        result = (
-            db.session.query(GameState)
-            .filter_by(uuid=game_id, state_index=state_index)
-            .first_or_404()
-        )
-    db.session.commit()
-    game = pickle.loads(result.pickle_data)
-    return game

--- a/catanatron_server/catanatron_server/pickle.py
+++ b/catanatron_server/catanatron_server/pickle.py
@@ -2,6 +2,7 @@ import os
 import json
 import pickle
 
+
 # save game metadata as a json file in the pickle directory
 def save_game_pickle_metadata(game, pickle_game_states_dir):
     pickle_game_dir = f"{pickle_game_states_dir}/{game.id}"
@@ -24,7 +25,7 @@ def save_game_pickle_metadata(game, pickle_game_states_dir):
 # serialize and store game state using pickle
 def save_game_state_to_pickle(game, state_index, pickle_game_states_dir):
     pickle_game_dir = f"{pickle_game_states_dir}/{game.id}"
-    
+
     # create pickle directory if it doesn't exist
     if not os.path.exists(pickle_game_dir):
         os.makedirs(pickle_game_dir)
@@ -32,6 +33,6 @@ def save_game_state_to_pickle(game, state_index, pickle_game_states_dir):
     # save pickle data to file
     with open(f"{pickle_game_dir}/{state_index}.pickle", "wb") as f:
         pickle.dump(game, f)
-    
+
     # update metadata
     save_game_pickle_metadata(game, pickle_game_states_dir)

--- a/catanatron_server/catanatron_server/pickle.py
+++ b/catanatron_server/catanatron_server/pickle.py
@@ -1,0 +1,37 @@
+import os
+import json
+import pickle
+
+# save game metadata as a json file in the pickle directory
+def save_game_pickle_metadata(game, pickle_game_states_dir):
+    pickle_game_dir = f"{pickle_game_states_dir}/{game.id}"
+
+    # create pickle directory if it doesn't exist
+    if not os.path.exists(pickle_game_dir):
+        os.makedirs(pickle_game_dir)
+
+    # save game metadata as a json file
+    with open(f"{pickle_game_dir}/metadata.json", "w") as f:
+        metadata = {
+            "id": game.id,
+            "players": [str(player.value) for player in game.state.colors],
+            "winner": str(game.winning_color()),
+            "game_states_count": len(game.state.actions),
+        }
+        json.dump(metadata, f)
+
+
+# serialize and store game state using pickle
+def save_game_state_to_pickle(game, state_index, pickle_game_states_dir):
+    pickle_game_dir = f"{pickle_game_states_dir}/{game.id}"
+    
+    # create pickle directory if it doesn't exist
+    if not os.path.exists(pickle_game_dir):
+        os.makedirs(pickle_game_dir)
+
+    # save pickle data to file
+    with open(f"{pickle_game_dir}/{state_index}.pickle", "wb") as f:
+        pickle.dump(game, f)
+    
+    # update metadata
+    save_game_pickle_metadata(game, pickle_game_states_dir)

--- a/catanatron_server/catanatron_server/utils.py
+++ b/catanatron_server/catanatron_server/utils.py
@@ -1,6 +1,52 @@
+import pickle
 import webbrowser
+from catanatron_server.models import db, GameState
+from catanatron.models.player import RandomPlayer
+from catanatron_experimental.machine_learning.players.value import ValueFunctionPlayer
+from catanatron_experimental.machine_learning.players.minimax import AlphaBetaPlayer
 
-from catanatron_server.models import database_session, upsert_game_state
+from catanatron_server.models import database_session
+
+
+# serialize and store game state using db
+def save_game_state_to_db(game, session_param=None):
+    game_state = GameState.from_game(game)
+    
+    session = session_param or db.session
+    session.add(game_state)
+    session.commit()
+    
+    return game_state
+
+
+def get_game_state_from_db(game_id, state_index=None):
+    if state_index is None:
+        result = (
+            db.session.query(GameState)
+            .filter_by(uuid=game_id)
+            .order_by(GameState.state_index.desc())
+            .first_or_404()
+        )
+    else:
+        result = (
+            db.session.query(GameState)
+            .filter_by(uuid=game_id, state_index=state_index)
+            .first_or_404()
+        )
+    db.session.commit()
+    game = pickle.loads(result.pickle_data)
+    return game
+
+
+def player_factory(player_key):
+    if player_key[0] == "CATANATRON":
+        return AlphaBetaPlayer(player_key[1], 2, True)
+    elif player_key[0] == "RANDOM":
+        return RandomPlayer(player_key[1])
+    elif player_key[0] == "HUMAN":
+        return ValueFunctionPlayer(player_key[1], is_bot=False)
+    else:
+        raise ValueError("Invalid player key")
 
 
 def ensure_link(game):
@@ -10,7 +56,7 @@ def ensure_link(game):
         str: URL for inspecting state, per convention
     """
     with database_session() as session:
-        game_state = upsert_game_state(game, session)
+        game_state = save_game_state_to_db(game, session)
         url = f"http://localhost:3000/games/{game_state.uuid}/states/{game_state.state_index}"
     return url
 

--- a/catanatron_server/catanatron_server/utils.py
+++ b/catanatron_server/catanatron_server/utils.py
@@ -11,11 +11,11 @@ from catanatron_server.models import database_session
 # serialize and store game state using db
 def save_game_state_to_db(game, session_param=None):
     game_state = GameState.from_game(game)
-    
+
     session = session_param or db.session
     session.add(game_state)
     session.commit()
-    
+
     return game_state
 
 


### PR DESCRIPTION
* move utility functions in `catanatron_server` to `utils.py`
* create `catanatron_server.pickle` module for operations on pickle files
* add ability to save game states when using main script to local pickle files with the `--pickle` and `--pickle-output` flags

this retains `--db` support.