### PR TITLE
refactor server files

### DIFF
--- a/catanatron_experimental/catanatron_experimental/cli/accumulators.py
+++ b/catanatron_experimental/catanatron_experimental/cli/accumulators.py
@@ -15,8 +15,8 @@ from catanatron.state_functions import (
     get_player_buildings,
 )
 from catanatron.models.enums import VICTORY_POINT, SETTLEMENT, CITY
-from catanatron_server.models import database_session, upsert_game_state
-from catanatron_server.utils import ensure_link
+from catanatron_server.models import database_session
+from catanatron_server.utils import ensure_link, save_game_state_to_db
 from catanatron_experimental.utils import formatSecs
 from catanatron_experimental.machine_learning.utils import (
     get_discounted_return,
@@ -145,11 +145,11 @@ class StepDatabaseAccumulator(GameAccumulator):
 
     def before(self, game):
         with database_session() as session:
-            upsert_game_state(game, session)
+            save_game_state_to_db(game, session)
 
     def step(self, game):
         with database_session() as session:
-            upsert_game_state(game, session)
+            save_game_state_to_db(game, session)
 
 
 class DatabaseAccumulator(GameAccumulator):

--- a/catanatron_server/catanatron_server/api.py
+++ b/catanatron_server/catanatron_server/api.py
@@ -1,98 +1,37 @@
-import json
+from flask import Blueprint, request
 
-from flask import Response, Blueprint, jsonify, abort, request
-
-from catanatron_server.models import upsert_game_state, get_game_state
-from catanatron.json import GameEncoder, action_from_json
-from catanatron.models.player import Color, RandomPlayer
-from catanatron.game import Game
-from catanatron_experimental.machine_learning.players.value import ValueFunctionPlayer
-from catanatron_experimental.machine_learning.players.minimax import AlphaBetaPlayer
+from catanatron_server.views import (
+    get_game_view,
+    post_game_view,
+    stress_test_view,
+    post_action_view,
+)
 
 
 bp = Blueprint("api", __name__, url_prefix="/api")
 
 
-def player_factory(player_key):
-    if player_key[0] == "CATANATRON":
-        return AlphaBetaPlayer(player_key[1], 2, True)
-    elif player_key[0] == "RANDOM":
-        return RandomPlayer(player_key[1])
-    elif player_key[0] == "HUMAN":
-        return ValueFunctionPlayer(player_key[1], is_bot=False)
-    else:
-        raise ValueError("Invalid player key")
-
-
 @bp.route("/games", methods=("POST",))
 def post_game_endpoint():
     player_keys = request.json["players"]
-    players = list(map(player_factory, zip(player_keys, Color)))
 
-    game = Game(players=players)
-    upsert_game_state(game)
-    return jsonify({"game_id": game.id})
+    return post_game_view(player_keys)
 
 
 @bp.route("/games/<string:game_id>/states/<string:state_index>", methods=("GET",))
 def get_game_endpoint(game_id, state_index):
-    state_index = None if state_index == "latest" else int(state_index)
-    game = get_game_state(game_id, state_index)
-    if game is None:
-        abort(404, description="Resource not found")
-
-    return Response(
-        response=json.dumps(game, cls=GameEncoder),
-        status=200,
-        mimetype="application/json",
-    )
+    return get_game_view(game_id, state_index)
 
 
 @bp.route("/games/<string:game_id>/actions", methods=["POST"])
 def post_action_endpoint(game_id):
-    game = get_game_state(game_id)
-    if game is None:
-        abort(404, description="Resource not found")
 
-    if game.winning_color() is not None:
-        return Response(
-            response=json.dumps(game, cls=GameEncoder),
-            status=200,
-            mimetype="application/json",
-        )
-
-    # TODO: remove `or body_is_empty` when fully implement actions in FE
-    body_is_empty = (not request.data) or request.json is None
-    if game.state.current_player().is_bot or body_is_empty:
-        game.play_tick()
-        upsert_game_state(game)
-    else:
-        action = action_from_json(request.json)
-        game.execute(action)
-        upsert_game_state(game)
-
-    return Response(
-        response=json.dumps(game, cls=GameEncoder),
-        status=200,
-        mimetype="application/json",
-    )
+    return post_action_view(game_id, request)
 
 
 @bp.route("/stress-test", methods=["GET"])
 def stress_test_endpoint():
-    players = [
-        AlphaBetaPlayer(Color.RED, 2, True),
-        AlphaBetaPlayer(Color.BLUE, 2, True),
-        AlphaBetaPlayer(Color.ORANGE, 2, True),
-        AlphaBetaPlayer(Color.WHITE, 2, True),
-    ]
-    game = Game(players=players)
-    game.play_tick()
-    return Response(
-        response=json.dumps(game, cls=GameEncoder),
-        status=200,
-        mimetype="application/json",
-    )
+    return stress_test_view()
 
 
 # ===== Debugging Routes

--- a/catanatron_server/catanatron_server/models.py
+++ b/catanatron_server/catanatron_server/models.py
@@ -58,30 +58,3 @@ def database_session():
     finally:
         session.expunge_all()
         session.close()
-
-
-def upsert_game_state(game, session_param=None):
-    game_state = GameState.from_game(game)
-    session = session_param or db.session
-    session.add(game_state)
-    session.commit()
-    return game_state
-
-
-def get_game_state(game_id, state_index=None):
-    if state_index is None:
-        result = (
-            db.session.query(GameState)
-            .filter_by(uuid=game_id)
-            .order_by(GameState.state_index.desc())
-            .first_or_404()
-        )
-    else:
-        result = (
-            db.session.query(GameState)
-            .filter_by(uuid=game_id, state_index=state_index)
-            .first_or_404()
-        )
-    db.session.commit()
-    game = pickle.loads(result.pickle_data)
-    return game

--- a/catanatron_server/catanatron_server/utils.py
+++ b/catanatron_server/catanatron_server/utils.py
@@ -1,6 +1,52 @@
+import pickle
 import webbrowser
+from catanatron_server.models import db, GameState
+from catanatron.models.player import RandomPlayer
+from catanatron_experimental.machine_learning.players.value import ValueFunctionPlayer
+from catanatron_experimental.machine_learning.players.minimax import AlphaBetaPlayer
 
-from catanatron_server.models import database_session, upsert_game_state
+from catanatron_server.models import database_session
+
+
+# serialize and store game state using db
+def save_game_state_to_db(game, session_param=None):
+    game_state = GameState.from_game(game)
+
+    session = session_param or db.session
+    session.add(game_state)
+    session.commit()
+
+    return game_state
+
+
+def get_game_state_from_db(game_id, state_index=None):
+    if state_index is None:
+        result = (
+            db.session.query(GameState)
+            .filter_by(uuid=game_id)
+            .order_by(GameState.state_index.desc())
+            .first_or_404()
+        )
+    else:
+        result = (
+            db.session.query(GameState)
+            .filter_by(uuid=game_id, state_index=state_index)
+            .first_or_404()
+        )
+    db.session.commit()
+    game = pickle.loads(result.pickle_data)
+    return game
+
+
+def player_factory(player_key):
+    if player_key[0] == "CATANATRON":
+        return AlphaBetaPlayer(player_key[1], 2, True)
+    elif player_key[0] == "RANDOM":
+        return RandomPlayer(player_key[1])
+    elif player_key[0] == "HUMAN":
+        return ValueFunctionPlayer(player_key[1], is_bot=False)
+    else:
+        raise ValueError("Invalid player key")
 
 
 def ensure_link(game):
@@ -10,7 +56,7 @@ def ensure_link(game):
         str: URL for inspecting state, per convention
     """
     with database_session() as session:
-        game_state = upsert_game_state(game, session)
+        game_state = save_game_state_to_db(game, session)
         url = f"http://localhost:3000/games/{game_state.uuid}/states/{game_state.state_index}"
     return url
 

--- a/catanatron_server/catanatron_server/views.py
+++ b/catanatron_server/catanatron_server/views.py
@@ -1,0 +1,79 @@
+import json
+from flask import Response, abort, jsonify
+from .utils import (
+    get_game_state_from_db,
+    save_game_state_to_db,
+    player_factory,
+)
+from catanatron_server.models import GameEncoder
+from catanatron.models.player import Color
+from catanatron_experimental.machine_learning.players.minimax import AlphaBetaPlayer
+from catanatron.json import action_from_json
+from catanatron.game import Game
+
+
+def get_game_view(game_id, state_index):
+    state_index = None if state_index == "latest" else int(state_index)
+    game = get_game_state_from_db(game_id, state_index)
+    if game is None:
+        abort(404, description="Resource not found")
+
+    return Response(
+        response=json.dumps(game, cls=GameEncoder),
+        status=200,
+        mimetype="application/json",
+    )
+
+
+def post_game_view(player_keys):
+    players = list(map(player_factory, zip(player_keys, Color)))
+
+    game = Game(players=players)
+    save_game_state_to_db(game, game.state_index)
+
+    return jsonify({"game_id": game.id, "state_index": game.state_index})
+
+
+def post_action_view(game_id, request):
+    game = get_game_state_from_db(game_id)
+    if game is None:
+        abort(404, description="Resource not found")
+
+    if game.winning_color() is not None:
+        return Response(
+            response=json.dumps(game, cls=GameEncoder),
+            status=200,
+            mimetype="application/json",
+        )
+
+    # TODO: remove `or body_is_empty` when fully implement actions in FE
+    body_is_empty = (not request.data) or request.json is None
+    if game.state.current_player().is_bot or body_is_empty:
+        game.play_tick()
+        save_game_state_to_db(game)
+    else:
+        action = action_from_json(request.json)
+        game.execute(action)
+        save_game_state_to_db(game)
+
+    return Response(
+        response=json.dumps(game, cls=GameEncoder),
+        status=200,
+        mimetype="application/json",
+    )
+
+
+def stress_test_view():
+    players = [
+        AlphaBetaPlayer(Color.RED, 2, True),
+        AlphaBetaPlayer(Color.BLUE, 2, True),
+        AlphaBetaPlayer(Color.ORANGE, 2, True),
+        AlphaBetaPlayer(Color.WHITE, 2, True),
+    ]
+    game = Game(players=players)
+    game.play_tick()
+    return Response(
+        response=json.dumps(game, cls=GameEncoder),
+        status=200,
+        mimetype="application/json",
+    )


### PR DESCRIPTION
* create `server.views` module for http views and extract them from `server.api`
* extract any extra logic from `server.api` or `server.models` to `server.utils`
* rename `upsert_game_state` to `save_game_state_to_db`

I wanted to do this before adding more endpoints and functionality to the server, since I think this structure is more orderly and easier to work with.