### PR TITLE
FEATURE: add game replay

### DIFF
--- a/catanatron/catanatron/json.py
+++ b/catanatron/catanatron/json.py
@@ -10,6 +10,7 @@ from catanatron.game import Game
 from catanatron.models.player import Color
 from catanatron.models.enums import RESOURCES, Action, ActionType
 from catanatron.state_functions import get_longest_road_length
+from catanatron.web.models import GameState
 
 
 def longest_roads_by_player(state):
@@ -100,6 +101,7 @@ class GameEncoder(json.JSONEncoder):
                 "current_playable_actions": obj.state.playable_actions,
                 "longest_roads_by_player": longest_roads_by_player(obj.state),
                 "winning_color": obj.winning_color(),
+                "state_index": GameState.get_state_index(obj),
             }
         if isinstance(obj, Water):
             return {"type": "WATER"}

--- a/catanatron/catanatron/json.py
+++ b/catanatron/catanatron/json.py
@@ -9,8 +9,7 @@ from catanatron.models.map import Water, Port, LandTile
 from catanatron.game import Game
 from catanatron.models.player import Color
 from catanatron.models.enums import RESOURCES, Action, ActionType
-from catanatron.state_functions import get_longest_road_length
-from catanatron.web.models import GameState
+from catanatron.state_functions import get_longest_road_length, get_state_index
 
 
 def longest_roads_by_player(state):
@@ -101,7 +100,7 @@ class GameEncoder(json.JSONEncoder):
                 "current_playable_actions": obj.state.playable_actions,
                 "longest_roads_by_player": longest_roads_by_player(obj.state),
                 "winning_color": obj.winning_color(),
-                "state_index": GameState.get_state_index(obj),
+                "state_index": get_state_index(obj.state),
             }
         if isinstance(obj, Water):
             return {"type": "WATER"}

--- a/catanatron/catanatron/state_functions.py
+++ b/catanatron/catanatron/state_functions.py
@@ -158,6 +158,10 @@ def get_player_freqdeck(state, color):
     ]
 
 
+def get_state_index(state) -> int:
+    return len(state.actions)
+
+
 # ===== State Mutators
 def build_settlement(state, color, node_id, is_free):
     state.buildings_by_color[color][SETTLEMENT].append(node_id)

--- a/catanatron/catanatron/web/api.py
+++ b/catanatron/catanatron/web/api.py
@@ -42,18 +42,13 @@ def post_game_endpoint():
 @bp.route("/games/<string:game_id>/states/<string:state_index>", methods=("GET",))
 def get_game_endpoint(game_id, state_index):
     parsed_state_index = _parse_state_index(state_index)
-    result = get_game_state(game_id, parsed_state_index)
-    if result is None:
+    game = get_game_state(game_id, parsed_state_index)
+    if game is None:
         abort(404, description="Resource not found")
 
-    game, result_state_index = result
-    payload = {
-        "state_index": result_state_index,
-        "state": game,
-    }
-
+    payload = json.dumps(game, cls=GameEncoder)
     return Response(
-        response=json.dumps(payload, cls=GameEncoder),
+        response=payload,
         status=200,
         mimetype="application/json",
     )
@@ -61,11 +56,10 @@ def get_game_endpoint(game_id, state_index):
 
 @bp.route("/games/<string:game_id>/actions", methods=["POST"])
 def post_action_endpoint(game_id):
-    result = get_game_state(game_id)
-    if result is None:
+    game = get_game_state(game_id)
+    if game is None:
         abort(404, description="Resource not found")
 
-    game, _ = result
     if game.winning_color() is not None:
         return Response(
             response=json.dumps(game, cls=GameEncoder),
@@ -117,14 +111,13 @@ def mcts_analysis_endpoint(game_id, state_index):
     # Convert 'latest' to None for consistency with get_game_state
     parsed_state_index = _parse_state_index(state_index)
     try:
-        result = get_game_state(game_id, parsed_state_index)
-        if result is None:
+        game = get_game_state(game_id, parsed_state_index)
+        if game is None:
             logging.error(
                 f"Game/state not found: {game_id}/{state_index}"
             )  # Use original state_index for logging
             abort(404, description="Game state not found")
 
-        game, _ = result
         analyzer = GameAnalyzer(num_simulations=100)
         probabilities = analyzer.analyze_win_probabilities(game)
 

--- a/catanatron/catanatron/web/api.py
+++ b/catanatron/catanatron/web/api.py
@@ -123,7 +123,7 @@ def mcts_analysis_endpoint(game_id, state_index):
                 f"Game/state not found: {game_id}/{state_index}"
             )  # Use original state_index for logging
             abort(404, description="Game state not found")
-        
+
         game, _ = result
         analyzer = GameAnalyzer(num_simulations=100)
         probabilities = analyzer.analyze_win_probabilities(game)

--- a/catanatron/catanatron/web/models.py
+++ b/catanatron/catanatron/web/models.py
@@ -2,6 +2,7 @@ import os
 import json
 import pickle
 from contextlib import contextmanager
+from typing import Any, Tuple
 
 from sqlalchemy import MetaData, Column, Integer, String, LargeBinary, create_engine
 from sqlalchemy.ext.declarative import declarative_base
@@ -69,7 +70,11 @@ def upsert_game_state(game, session_param=None):
     return game_state
 
 
-def get_game_state(game_id, state_index=None):
+def get_game_state(game_id, state_index=None) -> Tuple[Any, int] | None:
+    """
+    Returns the pickled game state and the state index of that game state.
+    The state index is useful when frontend queries for the latest state
+    """
     if state_index is None:
         result = (
             db.session.query(GameState)
@@ -89,4 +94,7 @@ def get_game_state(game_id, state_index=None):
             abort(404)
     db.session.commit()
     game = pickle.loads(result.pickle_data)  # type: ignore
-    return game
+    if game is None:
+        return None
+
+    return game, result.state_index

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -9,6 +9,7 @@ import HomePage from "./pages/HomePage";
 import { StateProvider } from "./store";
 
 import "./App.scss";
+import ReplayScreen from "./pages/ReplayScreen";
 
 const theme = createTheme({
   palette: {
@@ -37,6 +38,10 @@ function App() {
               <Route
                 path="/games/:gameId/states/:stateIndex"
                 element={<GameScreen replayMode={true} />}
+              />
+              <Route
+                path="/replays/:gameId"
+                element={<ReplayScreen/>}
               />
               <Route
                 path="/games/:gameId"

--- a/ui/src/components/AnalysisBox.scss
+++ b/ui/src/components/AnalysisBox.scss
@@ -1,0 +1,63 @@
+@use "../variables.scss";
+
+$dark-divider: rgb(0 0 0 / 80%);
+
+.analysis-box {
+  .loading-indicator {
+    text-align: center;
+    padding: 16px;
+    color: rgba(255, 255, 255, 0.7);
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    justify-content: center;
+  }
+
+  .probability-bars {
+    margin-bottom: 16px;
+    .probability-row {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 8px;
+      margin: 4px 0;
+      border-radius: 4px;
+      background: rgba(255, 255, 255, 0.05);
+  
+      &.red { color: variables.$red; }
+      &.blue { color: variables.$blue; }
+      &.white { color: variables.$white; }
+      &.orange { color: variables.$orange; }
+  
+      .player-color {
+        min-width: 63px;
+      }
+  
+      .probability-bar {
+        flex-grow: 1;
+        height: 20px;
+        margin: 0 12px;
+        background: rgba(255, 255, 255, 0.1);
+        border-radius: 4px;
+        overflow: hidden;
+        position: relative;
+        
+        .bar-fill {
+          position: absolute;
+          height: 100%;
+          left: 0;
+          top: 0;
+          background-color: currentColor;
+          opacity: 0.6;
+          transition: width 0.3s ease;
+        }
+      }
+  
+      .probability-value {
+        font-weight: 500;
+        min-width: 43px;
+        text-align: right;
+      }
+    }
+  }
+}

--- a/ui/src/components/AnalysisBox.tsx
+++ b/ui/src/components/AnalysisBox.tsx
@@ -1,13 +1,17 @@
 import { useContext, useState } from "react";
 import { CircularProgress, Button } from "@mui/material";
 import AssessmentIcon from "@mui/icons-material/Assessment";
-import { type MCTSProbabilities, getMctsAnalysis } from "../utils/apiClient";
+import { type MCTSProbabilities, type StateIndex, getMctsAnalysis } from "../utils/apiClient";
 import { useParams } from "react-router";
 
 import "./AnalysisBox.scss";
 import { store } from "../store";
 
-export default function AnalysisBox() {
+type AnalysisBoxProps = {
+    stateIndex: StateIndex;
+}
+
+export default function AnalysisBox( { stateIndex }: AnalysisBoxProps ) {
   const { gameId } = useParams();
   const { state } = useContext(store);
   const [mctsResults, setMctsResults] = useState<MCTSProbabilities | undefined>(undefined);
@@ -20,7 +24,7 @@ export default function AnalysisBox() {
     try {
       setLoading(true);
       setError('');
-      const result = await getMctsAnalysis(gameId);
+      const result = await getMctsAnalysis(gameId, stateIndex);
       if (result.success) {
         setMctsResults(result.probabilities);
       } else {

--- a/ui/src/components/AnalysisBox.tsx
+++ b/ui/src/components/AnalysisBox.tsx
@@ -1,0 +1,82 @@
+import { useContext, useState } from "react";
+import { CircularProgress, Button } from "@mui/material";
+import AssessmentIcon from "@mui/icons-material/Assessment";
+import { type MCTSProbabilities, getMctsAnalysis } from "../utils/apiClient";
+import { useParams } from "react-router";
+
+import "./AnalysisBox.scss";
+import { store } from "../store";
+
+export default function AnalysisBox() {
+  const { gameId } = useParams();
+  const { state } = useContext(store);
+  const [mctsResults, setMctsResults] = useState<MCTSProbabilities | undefined>(undefined);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  const handleAnalyzeClick = async () => {
+    if (!gameId || !state.gameState || state.gameState.winning_color) return;
+
+    try {
+      setLoading(true);
+      setError('');
+      const result = await getMctsAnalysis(gameId);
+      if (result.success) {
+        setMctsResults(result.probabilities);
+      } else {
+        setError(result.error || "Analysis failed");
+      }
+    } catch (err) {
+      console.error("MCTS Analysis failed:", err);
+      if (err instanceof Error) {
+        setError(err.message);
+      } else if (typeof err === "string") {
+        setError(err);
+      } else {
+        setError("An unknown error occurred");
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="analysis-box">
+      <div className="analysis-header">
+        <h3>Win Probability Analysis</h3>
+        <Button
+          variant="contained"
+          color="primary"
+          onClick={handleAnalyzeClick}
+          disabled={loading || !!state.gameState?.winning_color}
+          startIcon={loading ? <CircularProgress size={20} /> : <AssessmentIcon />}
+        >
+          {loading ? "Analyzing..." : "Analyze"}
+        </Button>
+      </div>
+
+      {error && (
+        <div className="error-message">
+          {error}
+        </div>
+      )}
+
+      {mctsResults && !loading && !error && (
+        <div className="probability-bars">
+          {Object.entries(mctsResults).map(([color, probability]) => (
+            <div key={color} className={`probability-row ${color.toLowerCase()}`}>
+              <span className="player-color">{color}</span>
+              <span className="probability-bar">
+                <div
+                  className="bar-fill"
+                  style={{ width: `${probability}%` }}
+                />
+              </span>
+              <span className="probability-value">{probability}%</span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ui/src/components/NumericTextInput.scss
+++ b/ui/src/components/NumericTextInput.scss
@@ -1,0 +1,15 @@
+.numeric-textfield {
+  .MuiOutlinedInput-root fieldset {
+    border-color: #1976d2;
+  }
+  
+  .MuiInputLabel-root {
+    color: #1976d2;
+    font-weight: 600;
+  }
+  
+  .MuiInputBase-input {
+    color: #1976d2;
+    font-weight: 600;
+  }
+}

--- a/ui/src/components/NumericTextInput.tsx
+++ b/ui/src/components/NumericTextInput.tsx
@@ -1,0 +1,40 @@
+import { TextField } from "@mui/material";
+import React from "react";
+import { allowOnlyNumberKeys } from "../utils/events";
+
+import "./NumericTextInput.scss"
+
+type NumericTextInputProps = Omit<
+  React.ComponentProps<typeof TextField>, "onChange"
+> & {
+  value: string;
+  onChange: (value: string) => void;
+  onCommit?: () => void;
+};
+
+export default function NumericTextInput({
+  value,
+  onChange,
+  onCommit,
+  ...props
+}: NumericTextInputProps) {
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    allowOnlyNumberKeys(e);
+    if (e.key === "Enter") {
+      e.preventDefault();
+      onCommit?.();
+    }
+  };
+
+  return (
+    <TextField
+      {...props}
+      className="numeric-textfield"
+      type="text"
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      onKeyDown={handleKeyDown}
+      onBlur={onCommit}
+    />
+  );
+}

--- a/ui/src/components/ReplayBox.scss
+++ b/ui/src/components/ReplayBox.scss
@@ -1,0 +1,10 @@
+.replay-box {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+
+  .button-container {
+    display: flex;
+    gap: 10px;
+  }
+}

--- a/ui/src/components/ReplayBox.tsx
+++ b/ui/src/components/ReplayBox.tsx
@@ -1,0 +1,86 @@
+import { ArrowBackIos, ArrowForwardIos } from "@mui/icons-material";
+import { Button, Slider } from "@mui/material";
+
+import "./ReplayBox.scss";
+import { useState } from "react";
+import NumericTextInput from "./NumericTextInput";
+
+type ReplayBoxProps = {
+  stateIndex: number;
+  latestStateIndex: number;
+  onPrevMove: () => void;
+  onNextMove: () => void;
+  onSeekMove: (value: number) => void;
+};
+
+export default function ReplayBox({stateIndex,
+  latestStateIndex,
+  onPrevMove,
+  onNextMove,
+  onSeekMove
+}: ReplayBoxProps ) {
+  const [inputValue, setInputValue] = useState<string>(String(stateIndex));
+
+  const commitInput = () => {
+    if (inputValue.trim() === "") {
+      setInputValue(String(stateIndex));
+      return;
+    }
+    const parsed = Number(inputValue);
+    if (!Number.isFinite(parsed)) {
+      setInputValue(String(stateIndex));
+      return;
+    }
+    const next = Math.max(0, Math.min(latestStateIndex, Math.trunc(parsed)));
+    setInputValue(String(next));
+    if (next !== stateIndex) onSeekMove(next);
+  };
+
+  return (
+    <div className="replay-box">
+      <h3>Replay</h3>
+
+      Move: {stateIndex} / {latestStateIndex}
+
+      <Slider
+        className="move-slider"
+        min={0}
+        max={latestStateIndex}
+        step={1}
+        value={stateIndex}
+        onChange={(_, value) => onSeekMove(value as number)}
+      />
+
+      <NumericTextInput
+        label="Go to move"
+        size="small"
+        value={inputValue}
+        onChange={setInputValue}
+        onCommit={commitInput}
+      />
+
+      <div className="button-container">
+        <Button
+          variant="contained"
+          color="primary"
+          onClick={onPrevMove}
+          startIcon={<ArrowBackIos />}
+          disabled={stateIndex === 0}
+        >
+          Prev Move
+        </Button>
+
+        <Button
+          variant="contained"
+          color="primary"
+          onClick={onNextMove}
+          startIcon={<ArrowForwardIos />}
+          disabled={stateIndex === latestStateIndex}
+        >
+          Next Move
+        </Button>
+      </div>
+
+    </div>
+  )
+}

--- a/ui/src/components/RightDrawer.scss
+++ b/ui/src/components/RightDrawer.scss
@@ -3,6 +3,14 @@
 $dark-divider: rgb(0 0 0 / 80%);
 
 .right-drawer {
+  .drawer-content {
+    padding: variables.$sm-gutter;
+
+    display: flex;
+    flex-direction: column;
+    gap: variables.$sm-gutter;
+  }
+
   .MuiDrawer-paper {
     width: 280px;
     background: variables.$dark-gray;
@@ -11,76 +19,5 @@ $dark-divider: rgb(0 0 0 / 80%);
 
   .MuiDivider-root {
     background: $dark-divider;
-  }
-
-  .analysis-box {
-    padding: variables.$sm-gutter;
-
-    h3 {
-      margin-bottom: 16px;
-      font-size: 1.2rem;
-    }
-
-    .analysis-header {
-      margin-bottom: 24px;
-    }
-
-    .loading-indicator {
-      text-align: center;
-      padding: 16px;
-      color: rgba(255, 255, 255, 0.7);
-      display: flex;
-      align-items: center;
-      gap: 8px;
-      justify-content: center;
-    }
-
-    .probability-bars {
-      margin-bottom: 16px;
-      .probability-row {
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-        padding: 8px;
-        margin: 4px 0;
-        border-radius: 4px;
-        background: rgba(255, 255, 255, 0.05);
-    
-        &.red { color: variables.$red; }
-        &.blue { color: variables.$blue; }
-        &.white { color: variables.$white; }
-        &.orange { color: variables.$orange; }
-    
-        .player-color {
-          min-width: 63px;
-        }
-    
-        .probability-bar {
-          flex-grow: 1;
-          height: 20px;
-          margin: 0 12px;
-          background: rgba(255, 255, 255, 0.1);
-          border-radius: 4px;
-          overflow: hidden;
-          position: relative;
-          
-          .bar-fill {
-            position: absolute;
-            height: 100%;
-            left: 0;
-            top: 0;
-            background-color: currentColor;
-            opacity: 0.6;
-            transition: width 0.3s ease;
-          }
-        }
-    
-        .probability-value {
-          font-weight: 500;
-          min-width: 43px;
-          text-align: right;
-        }
-      }
-    }
   }
 }

--- a/ui/src/components/RightDrawer.tsx
+++ b/ui/src/components/RightDrawer.tsx
@@ -1,12 +1,7 @@
-import { useCallback, useContext, useState } from "react";
+import { useCallback, useContext, type PropsWithChildren } from "react";
 import SwipeableDrawer from "@mui/material/SwipeableDrawer";
-import Divider from "@mui/material/Divider";
 import Drawer from "@mui/material/Drawer";
-import { CircularProgress, Button } from "@mui/material";
-import AssessmentIcon from "@mui/icons-material/Assessment";
-import { type MCTSProbabilities, getMctsAnalysis } from "../utils/apiClient";
 import { isTabOrShift, type InteractionEvent } from "../utils/events";
-import { useParams } from "react-router";
 
 import Hidden from "./Hidden";
 import { store } from "../store";
@@ -14,82 +9,7 @@ import ACTIONS from "../actions";
 
 import "./RightDrawer.scss";
 
-function DrawerContent() {
-  const { gameId } = useParams();
-  const { state } = useContext(store);
-  const [mctsResults, setMctsResults] = useState<MCTSProbabilities | undefined>(undefined);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState('');
-
-  const handleAnalyzeClick = async () => {
-    if (!gameId || !state.gameState || state.gameState.winning_color) return;
-
-    try {
-      setLoading(true);
-      setError('');
-      const result = await getMctsAnalysis(gameId);
-      if (result.success) {
-        setMctsResults(result.probabilities);
-      } else {
-        setError(result.error || "Analysis failed");
-      }
-    } catch (err) {
-      console.error("MCTS Analysis failed:", err);
-      if (err instanceof Error) {
-        setError(err.message);
-      } else if (typeof err === "string") {
-        setError(err);
-      } else {
-        setError("An unknown error occurred");
-      }
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  return (
-    <div className="analysis-box">
-      <div className="analysis-header">
-        <h3>Win Probability Analysis</h3>
-        <Button
-          variant="contained"
-          color="primary"
-          onClick={handleAnalyzeClick}
-          disabled={loading || !!state.gameState?.winning_color}
-          startIcon={loading ? <CircularProgress size={20} /> : <AssessmentIcon />}
-        >
-          {loading ? "Analyzing..." : "Analyze"}
-        </Button>
-      </div>
-
-      {error && (
-        <div className="error-message">
-          {error}
-        </div>
-      )}
-
-      {mctsResults && !loading && !error && (
-        <div className="probability-bars">
-          {Object.entries(mctsResults).map(([color, probability]) => (
-            <div key={color} className={`probability-row ${color.toLowerCase()}`}>
-              <span className="player-color">{color}</span>
-              <span className="probability-bar">
-                <div
-                  className="bar-fill"
-                  style={{ width: `${probability}%` }}
-                />
-              </span>
-              <span className="probability-value">{probability}%</span>
-            </div>
-          ))}
-        </div>
-      )}
-      <Divider />
-    </div>
-  );
-}
-
-export default function RightDrawer() {
+export default function RightDrawer( { children }: PropsWithChildren ) {
   const { state, dispatch } = useContext(store);
   const iOS = /iPad|iPhone|iPod/.test(navigator.userAgent);
 
@@ -128,7 +48,9 @@ export default function RightDrawer() {
           disableDiscovery={iOS}
           onKeyDown={closeRightDrawer}
         >
-          <DrawerContent />
+          <div className="drawer-content">
+            {children}
+          </div>
         </SwipeableDrawer>
       </Hidden>
       <Hidden breakpoint={{ size: "md", direction: "down" }} implementation="css">
@@ -138,7 +60,9 @@ export default function RightDrawer() {
           variant="permanent"
           open
         >
-          <DrawerContent />
+          <div className="drawer-content">
+            {children}
+          </div>
         </Drawer>
       </Hidden>
     </>

--- a/ui/src/pages/GameScreen.tsx
+++ b/ui/src/pages/GameScreen.tsx
@@ -33,7 +33,7 @@ function GameScreen({ replayMode }: { replayMode: boolean }) {
     }
 
     (async () => {
-      const gameState = await getState(gameId, stateIndex as StateIndex);
+      const { state: gameState } = await getState(gameId, stateIndex as StateIndex);
       dispatch({ type: ACTIONS.SET_GAME_STATE, data: gameState });
     })();
   }, [gameId, stateIndex, dispatch]);
@@ -91,7 +91,7 @@ function GameScreen({ replayMode }: { replayMode: boolean }) {
       <ActionsToolbar isBotThinking={isBotThinking} replayMode={replayMode} />
       <LeftDrawer />
       <RightDrawer>
-        <AnalysisBox />
+        <AnalysisBox stateIndex={"latest"}/>
         <Divider />
       </RightDrawer>
     </main>

--- a/ui/src/pages/GameScreen.tsx
+++ b/ui/src/pages/GameScreen.tsx
@@ -33,7 +33,7 @@ function GameScreen({ replayMode }: { replayMode: boolean }) {
     }
 
     (async () => {
-      const { state: gameState } = await getState(gameId, stateIndex as StateIndex);
+      const gameState = await getState(gameId, stateIndex as StateIndex);
       dispatch({ type: ACTIONS.SET_GAME_STATE, data: gameState });
     })();
   }, [gameId, stateIndex, dispatch]);

--- a/ui/src/pages/GameScreen.tsx
+++ b/ui/src/pages/GameScreen.tsx
@@ -15,6 +15,8 @@ import ACTIONS from "../actions";
 import { type StateIndex, getState, postAction } from "../utils/apiClient";
 import { dispatchSnackbar } from "../components/Snackbar";
 import { getHumanColor } from "../utils/stateUtils";
+import AnalysisBox from "../components/AnalysisBox";
+import { Divider } from "@mui/material";
 
 const ROBOT_THINKING_TIME = 300;
 
@@ -88,7 +90,10 @@ function GameScreen({ replayMode }: { replayMode: boolean }) {
       <ZoomableBoard replayMode={replayMode} />
       <ActionsToolbar isBotThinking={isBotThinking} replayMode={replayMode} />
       <LeftDrawer />
-      <RightDrawer />
+      <RightDrawer>
+        <AnalysisBox />
+        <Divider />
+      </RightDrawer>
     </main>
   );
 }

--- a/ui/src/pages/ReplayScreen.scss
+++ b/ui/src/pages/ReplayScreen.scss
@@ -1,0 +1,117 @@
+@use "../variables.scss";
+
+.MuiToolbar-root {
+  background: variables.$black;
+}
+
+h6.MuiTypography-h6 {
+  font-family: "Bungee Inline", sans-serif;
+}
+
+@media (min-width: 600px) {
+  #root .snackbar-container {
+    display: none;
+  }
+}
+
+// For Snackbar
+#root .snackbar-container {
+  z-index: 1200;
+  left: 50% !important;
+  bottom: 0px;
+  transform: translateX(-50%);
+  max-width: variables.$sm-breakpoint;
+  width: 100%;
+  .MuiCollapse-container {
+    padding: 0 10px;
+    width: 100%;
+    .MuiCollapse-wrapper {
+      margin-top: 10px;
+      margin-bottom: 10px;
+      height: 60px;
+      padding: 0;
+
+      > div > div {
+        height: 100%;
+
+        > div {
+          height: 100%;
+        }
+      }
+    }
+  }
+}
+
+main {
+  .logo {
+    margin: 5px 20px 0 20px;
+    text-align: center;
+  }
+
+  background: variables.$black;
+  color: white;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+
+  .loader {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+
+  .board-container,
+  .loader {
+    height: 100%;
+    width: 100%;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+}
+
+.board-container {
+  .react-transform-wrapper {
+      height: 100%;
+      width: 100%;
+    }
+  .react-transform-component {
+    height: 100%;
+    width: 100%;
+
+    .react-transform-element {
+      height: 100%;
+      width: 100%;
+    }
+  }
+
+  .board {
+    position: relative;
+    opacity: 0;
+    height: 100%;
+    width: 100%;
+  }
+  .board.show {
+    opacity: 1;
+  }
+}
+
+// Medium screens - Left drawer permanent
+@media (min-width: variables.$md-breakpoint) {
+  main {
+    padding-left: 280px;
+    .board-container {
+      margin-right: 0;
+    }
+  }
+}
+
+// Large screens - Both drawers permanent
+@media (min-width: variables.$lg-breakpoint) {
+  main {
+    padding-left: 0px;
+    .board-container {
+      margin-left: 140px;
+    }
+  }
+}

--- a/ui/src/pages/ReplayScreen.scss
+++ b/ui/src/pages/ReplayScreen.scss
@@ -1,117 +1,20 @@
 @use "../variables.scss";
 
-.MuiToolbar-root {
-  background: variables.$black;
-}
-
-h6.MuiTypography-h6 {
-  font-family: "Bungee Inline", sans-serif;
-}
-
-@media (min-width: 600px) {
-  #root .snackbar-container {
-    display: none;
-  }
-}
-
-// For Snackbar
-#root .snackbar-container {
-  z-index: 1200;
-  left: 50% !important;
-  bottom: 0px;
-  transform: translateX(-50%);
-  max-width: variables.$sm-breakpoint;
-  width: 100%;
-  .MuiCollapse-container {
-    padding: 0 10px;
-    width: 100%;
-    .MuiCollapse-wrapper {
-      margin-top: 10px;
-      margin-bottom: 10px;
-      height: 60px;
-      padding: 0;
-
-      > div > div {
-        height: 100%;
-
-        > div {
-          height: 100%;
-        }
-      }
-    }
-  }
-}
-
 main {
-  .logo {
-    margin: 5px 20px 0 20px;
-    text-align: center;
-  }
-
   background: variables.$black;
   color: white;
   height: 100%;
   display: flex;
   flex-direction: column;
 
+  .logo {
+    margin: 5px 20px 0 20px;
+    text-align: center;
+  }
+
   .loader {
     display: flex;
     justify-content: center;
     align-items: center;
-  }
-
-  .board-container,
-  .loader {
-    height: 100%;
-    width: 100%;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-  }
-}
-
-.board-container {
-  .react-transform-wrapper {
-      height: 100%;
-      width: 100%;
-    }
-  .react-transform-component {
-    height: 100%;
-    width: 100%;
-
-    .react-transform-element {
-      height: 100%;
-      width: 100%;
-    }
-  }
-
-  .board {
-    position: relative;
-    opacity: 0;
-    height: 100%;
-    width: 100%;
-  }
-  .board.show {
-    opacity: 1;
-  }
-}
-
-// Medium screens - Left drawer permanent
-@media (min-width: variables.$md-breakpoint) {
-  main {
-    padding-left: 280px;
-    .board-container {
-      margin-right: 0;
-    }
-  }
-}
-
-// Large screens - Both drawers permanent
-@media (min-width: variables.$lg-breakpoint) {
-  main {
-    padding-left: 0px;
-    .board-container {
-      margin-left: 140px;
-    }
   }
 }

--- a/ui/src/pages/ReplayScreen.tsx
+++ b/ui/src/pages/ReplayScreen.tsx
@@ -1,0 +1,63 @@
+import { useEffect, useContext } from "react";
+import { useParams } from "react-router-dom";
+import PropTypes from "prop-types";
+import { GridLoader } from "react-spinners";
+
+import ZoomableBoard from "./ZoomableBoard";
+import ActionsToolbar from "./ActionsToolbar";
+
+import "./ReplayScreen.scss";
+import LeftDrawer from "../components/LeftDrawer";
+import RightDrawer from "../components/RightDrawer";
+import { store } from "../store";
+import ACTIONS from "../actions";
+import { type StateIndex, getState } from "../utils/apiClient";
+
+function ReplayScreen() {
+  const { gameId } = useParams();
+  const { state, dispatch } = useContext(store);
+  let stateIndex = 2
+
+  useEffect(() => {
+    if (!gameId) {
+      return;
+    }
+
+    (async () => {
+      const gameState = await getState(gameId, stateIndex as StateIndex);
+      dispatch({ type: ACTIONS.SET_GAME_STATE, data: gameState });
+    })();
+  }, [gameId, stateIndex, dispatch]);
+
+  if (!state.gameState) {
+    return (
+      <main>
+        <GridLoader
+          className="loader"
+          color="#000000"
+          size={100}
+        />
+      </main>
+    );
+  }
+
+  return (
+    <main>
+      <h1 className="logo">Catanatron</h1>
+      <ZoomableBoard replayMode={true} />
+      <ActionsToolbar isBotThinking={false} replayMode={true} />
+      <LeftDrawer />
+      <RightDrawer />
+    </main>
+  );
+}
+
+ReplayScreen.propTypes = {
+  /**
+   * Injected by the documentation to work in an iframe.
+   * You won't need it on your project.
+   */
+  window: PropTypes.func,
+};
+
+export default ReplayScreen;

--- a/ui/src/pages/ReplayScreen.tsx
+++ b/ui/src/pages/ReplayScreen.tsx
@@ -1,22 +1,26 @@
-import { useEffect, useContext } from "react";
+import { useEffect, useContext, useState } from "react";
 import { useParams } from "react-router-dom";
-import PropTypes from "prop-types";
 import { GridLoader } from "react-spinners";
 
 import ZoomableBoard from "./ZoomableBoard";
 import ActionsToolbar from "./ActionsToolbar";
 
-import "./ReplayScreen.scss";
+// import "./ReplayScreen.scss";
 import LeftDrawer from "../components/LeftDrawer";
 import RightDrawer from "../components/RightDrawer";
 import { store } from "../store";
 import ACTIONS from "../actions";
 import { type StateIndex, getState } from "../utils/apiClient";
+import AnalysisBox from "../components/AnalysisBox";
+import { Divider } from "@mui/material";
 
 function ReplayScreen() {
   const { gameId } = useParams();
   const { state, dispatch } = useContext(store);
-  let stateIndex = 2
+  const [stateIndex, setStateIndex] = useState<number>(5);
+
+  const handlePrevState = () => setStateIndex((prev) => Math.max(prev - 1, 0));
+  const handleNextState = () => setStateIndex((prev) => prev + 1);
 
   useEffect(() => {
     if (!gameId) {
@@ -47,17 +51,12 @@ function ReplayScreen() {
       <ZoomableBoard replayMode={true} />
       <ActionsToolbar isBotThinking={false} replayMode={true} />
       <LeftDrawer />
-      <RightDrawer />
+      <RightDrawer>
+        <AnalysisBox />
+        <Divider />
+      </RightDrawer>
     </main>
   );
 }
-
-ReplayScreen.propTypes = {
-  /**
-   * Injected by the documentation to work in an iframe.
-   * You won't need it on your project.
-   */
-  window: PropTypes.func,
-};
 
 export default ReplayScreen;

--- a/ui/src/pages/ReplayScreen.tsx
+++ b/ui/src/pages/ReplayScreen.tsx
@@ -4,7 +4,7 @@ import { GridLoader } from "react-spinners";
 
 import ZoomableBoard from "./ZoomableBoard";
 
-// import "./ReplayScreen.scss";
+import "./ReplayScreen.scss";
 import LeftDrawer from "../components/LeftDrawer";
 import RightDrawer from "../components/RightDrawer";
 import { store } from "../store";

--- a/ui/src/pages/ReplayScreen.tsx
+++ b/ui/src/pages/ReplayScreen.tsx
@@ -18,7 +18,7 @@ function ReplayScreen() {
   const { gameId } = useParams();
   const { state, dispatch } = useContext(store);
   const [latestStateIndex, setLatestStateIndex] = useState<number>(0);
-  const [stateIndex, setStateIndex] = useState<number>(5);
+  const [stateIndex, setStateIndex] = useState<number>(0);
 
   const handlePrevState = () => setStateIndex((prev) => Math.max(prev - 1, 0));
   const handleNextState = () => setStateIndex((prev) => Math.min(prev + 1, latestStateIndex));

--- a/ui/src/pages/ReplayScreen.tsx
+++ b/ui/src/pages/ReplayScreen.tsx
@@ -27,9 +27,9 @@ function ReplayScreen() {
     if (!gameId) return;
 
     (async () => {
-      const { state: latestState, state_index: latestIndex } = await getState(gameId, "latest");
+      const latestState = await getState(gameId, "latest");
       dispatch({ type: ACTIONS.SET_GAME_STATE, data: latestState });
-      setLatestStateIndex(latestIndex);
+      setLatestStateIndex(latestState.state_index);
     })();
   }, [gameId, dispatch]);
 
@@ -39,7 +39,7 @@ function ReplayScreen() {
     }
 
     (async () => {
-      const { state: gameState } = await getState(gameId, stateIndex);
+      const gameState = await getState(gameId, stateIndex);
       dispatch({ type: ACTIONS.SET_GAME_STATE, data: gameState });
     })();
   }, [gameId, stateIndex, dispatch]);

--- a/ui/src/utils/api.types.ts
+++ b/ui/src/utils/api.types.ts
@@ -86,6 +86,7 @@ export type GameState = {
   is_initial_build_phase: boolean;
   edgeActions?: GameAction[];
   nodeActions?: GameAction[];
+  state_index: number;
 };
 const DIRECTIONS = [
   "NORTH",

--- a/ui/src/utils/apiClient.ts
+++ b/ui/src/utils/apiClient.ts
@@ -14,7 +14,7 @@ export async function createGame(players: Player[]) {
 export async function getState(
   gameId: string,
   stateIndex: StateIndex = "latest"
-) {
+): Promise<GameState> {
   const response = await axios.get(
     `${API_URL}/api/games/${gameId}/states/${stateIndex}`
   );

--- a/ui/src/utils/events.ts
+++ b/ui/src/utils/events.ts
@@ -1,3 +1,5 @@
+import { type KeyboardEvent } from "react";
+
 export type InteractionEvent =
   | React.KeyboardEvent
   | React.MouseEvent
@@ -10,3 +12,18 @@ export const isKeyDownEvent = (
 
 export const isTabOrShift = (event: InteractionEvent) =>
   isKeyDownEvent(event) && (event.key === "Tab" || event.key === "Shift");
+
+export function allowOnlyNumberKeys(e: KeyboardEvent<HTMLInputElement>) {
+  const allowedKeys = [
+    "Backspace",
+    "ArrowLeft",
+    "ArrowRight",
+    "Delete",
+    "Tab",
+    "Enter",
+  ];
+
+  if (!/[0-9]/.test(e.key) && !allowedKeys.includes(e.key)) {
+    e.preventDefault();
+  }
+}


### PR DESCRIPTION
Frontend changes:
- Closed #54, replay feature now implemented, it looks like this
<img width="1267" height="691" alt="image" src="https://github.com/user-attachments/assets/745487b6-7763-4d46-9e33-76f8b8b52773" />

- refactored some components: AnalysisBox, ReplayBox, RightDrawer
- new route: /replays/:gameId

Backend changes:
- route /games/<string:game_id>/states/<string:state_index> also returns the state_index along with game state (could be cleaner to put state_index inside of the game object we're returning)
