### PR TITLE
Deterministic Discards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,8 @@ __pycache__/
 build/
 develop-eggs/
 dist/
+.dist/
+db-data/
 downloads/
 eggs/
 .eggs/
@@ -137,4 +139,3 @@ dmypy.json
 # Pyre type checker
 .pyre/
 
-/db-data

--- a/catanatron/catanatron/apply_action.py
+++ b/catanatron/catanatron/apply_action.py
@@ -266,22 +266,21 @@ def apply_roll(state: State, action: Action, action_record=None):
     action = Action(action.color, action.action_type, dices)
 
     if number == 7:
-        state.discard_counts = [
-            (
-                player_num_resource_cards(state, color) // 2
-                if player_num_resource_cards(state, color) > state.discard_limit
-                else 0
-            )
-            for color in state.colors
-        ]
-        should_enter_discarding_sequence = any(
-            count > 0 for count in state.discard_counts
-        )
+        discard_counts = []
+        first_discarding_player_index = None
 
-        if should_enter_discarding_sequence:
-            state.current_player_index = next(
-                i for i, count in enumerate(state.discard_counts) if count > 0
-            )
+        for i, color in enumerate(state.colors):
+            num_cards = player_num_resource_cards(state, color)
+            discard_count = num_cards // 2 if num_cards > state.discard_limit else 0
+            discard_counts.append(discard_count)
+
+            if discard_count > 0 and first_discarding_player_index is None:
+                first_discarding_player_index = i
+
+        state.discard_counts = discard_counts
+
+        if first_discarding_player_index is not None:
+            state.current_player_index = first_discarding_player_index
             state.current_prompt = ActionPrompt.DISCARD
             state.is_discarding = True
         else:

--- a/catanatron/catanatron/apply_action.py
+++ b/catanatron/catanatron/apply_action.py
@@ -93,7 +93,7 @@ def apply_action(
         action_record = apply_buy_development_card(state, action, action_record)
     elif action.action_type == ActionType.ROLL:
         action_record = apply_roll(state, action, action_record)
-    elif action.action_type == ActionType.DISCARD:
+    elif action.action_type == ActionType.DISCARD_RESOURCE:
         action_record = apply_discard(state, action, action_record)
     elif action.action_type == ActionType.MOVE_ROBBER:
         action_record = apply_move_robber(state, action, action_record)
@@ -338,9 +338,9 @@ def apply_discard(state: State, action: Action, action_record=None):
         # state.current_prompt stays the same
         pass
     else:
-        discarders_left = [
-            state.discard_counts[color] > 0 for color in state.colors
-        ][state.current_player_index + 1 :]
+        discarders_left = [state.discard_counts[color] > 0 for color in state.colors][
+            state.current_player_index + 1 :
+        ]
         if any(discarders_left):
             to_skip = discarders_left.index(True)
             state.current_player_index = state.current_player_index + 1 + to_skip

--- a/catanatron/catanatron/apply_action.py
+++ b/catanatron/catanatron/apply_action.py
@@ -266,17 +266,26 @@ def apply_roll(state: State, action: Action, action_record=None):
     action = Action(action.color, action.action_type, dices)
 
     if number == 7:
-        discarders = [
-            player_num_resource_cards(state, color) > state.discard_limit
+        state.discard_counts = {
+            color: (
+                player_num_resource_cards(state, color) // 2
+                if player_num_resource_cards(state, color) > state.discard_limit
+                else 0
+            )
             for color in state.colors
-        ]
-        should_enter_discarding_sequence = any(discarders)
+        }
+        should_enter_discarding_sequence = any(state.discard_counts.values())
 
         if should_enter_discarding_sequence:
-            state.current_player_index = discarders.index(True)
+            state.current_player_index = next(
+                i
+                for i, color in enumerate(state.colors)
+                if state.discard_counts[color] > 0
+            )
             state.current_prompt = ActionPrompt.DISCARD
             state.is_discarding = True
         else:
+            state.discard_counts = {color: 0 for color in state.colors}
             # state.current_player_index stays the same
             state.current_prompt = ActionPrompt.MOVE_ROBBER
             state.is_moving_knight = True
@@ -295,33 +304,53 @@ def apply_roll(state: State, action: Action, action_record=None):
     return ActionRecord(action=action, result=dices)
 
 
-def apply_discard(state: State, action: Action, action_record=None):
+def normalize_discarded_cards(state: State, action: Action, action_record=None):
+    if action.value is not None:
+        if isinstance(action.value, (list, tuple)):
+            return list(action.value)
+        return [action.value]
+
+    if action_record is not None and action_record.result is not None:
+        if isinstance(action_record.result, (list, tuple)):
+            return list(action_record.result)
+        return [action_record.result]
+
     hand = player_deck_to_array(state, action.color)
-    num_to_discard = len(hand) // 2
-    if action_record is None:
-        # TODO: Forcefully discard randomly so that decision tree doesnt explode in possibilities.
-        discarded = random.sample(hand, k=num_to_discard)
-    else:
-        discarded = action_record.result  # for replay functionality
+    return [random.choice(hand)]
+
+
+def apply_discard(state: State, action: Action, action_record=None):
+    discarded = normalize_discarded_cards(state, action, action_record)
+    remaining = state.discard_counts[action.color]
+    if len(discarded) > remaining:
+        raise ValueError("Trying to discard more cards than required")
+
     to_discard = freqdeck_from_listdeck(discarded)
 
     player_freqdeck_subtract(state, action.color, to_discard)
     state.resource_freqdeck = freqdeck_add(state.resource_freqdeck, to_discard)
-    action = Action(action.color, action.action_type, discarded)
+    state.discard_counts[action.color] = remaining - len(discarded)
+    action_value = discarded[0] if len(discarded) == 1 else tuple(discarded)
+    action = Action(action.color, action.action_type, action_value)
 
-    # Advance turn
-    discarders_left = [
-        player_num_resource_cards(state, color) > 7 for color in state.colors
-    ][state.current_player_index + 1 :]
-    if any(discarders_left):
-        to_skip = discarders_left.index(True)
-        state.current_player_index = state.current_player_index + 1 + to_skip
+    if state.discard_counts[action.color] > 0:
+        # state.current_player_index stays the same
         # state.current_prompt stays the same
+        pass
     else:
-        state.current_player_index = state.current_turn_index
-        state.current_prompt = ActionPrompt.MOVE_ROBBER
-        state.is_discarding = False
-        state.is_moving_knight = True
+        discarders_left = [
+            state.discard_counts[color] > 0 for color in state.colors
+        ][state.current_player_index + 1 :]
+        if any(discarders_left):
+            to_skip = discarders_left.index(True)
+            state.current_player_index = state.current_player_index + 1 + to_skip
+            # state.current_prompt stays the same
+        else:
+            state.current_player_index = state.current_turn_index
+            state.current_prompt = ActionPrompt.MOVE_ROBBER
+            state.is_discarding = False
+            state.is_moving_knight = True
+            state.discard_counts = {color: 0 for color in state.colors}
 
     return ActionRecord(action=action, result=discarded)
 

--- a/catanatron/catanatron/apply_action.py
+++ b/catanatron/catanatron/apply_action.py
@@ -94,7 +94,7 @@ def apply_action(
     elif action.action_type == ActionType.ROLL:
         action_record = apply_roll(state, action, action_record)
     elif action.action_type == ActionType.DISCARD_RESOURCE:
-        action_record = apply_discard(state, action, action_record)
+        action_record = apply_discard(state, action)
     elif action.action_type == ActionType.MOVE_ROBBER:
         action_record = apply_move_robber(state, action, action_record)
     elif action.action_type == ActionType.PLAY_KNIGHT_CARD:
@@ -266,26 +266,26 @@ def apply_roll(state: State, action: Action, action_record=None):
     action = Action(action.color, action.action_type, dices)
 
     if number == 7:
-        state.discard_counts = {
-            color: (
+        state.discard_counts = [
+            (
                 player_num_resource_cards(state, color) // 2
                 if player_num_resource_cards(state, color) > state.discard_limit
                 else 0
             )
             for color in state.colors
-        }
-        should_enter_discarding_sequence = any(state.discard_counts.values())
+        ]
+        should_enter_discarding_sequence = any(
+            count > 0 for count in state.discard_counts
+        )
 
         if should_enter_discarding_sequence:
             state.current_player_index = next(
-                i
-                for i, color in enumerate(state.colors)
-                if state.discard_counts[color] > 0
+                i for i, count in enumerate(state.discard_counts) if count > 0
             )
             state.current_prompt = ActionPrompt.DISCARD
             state.is_discarding = True
         else:
-            state.discard_counts = {color: 0 for color in state.colors}
+            state.discard_counts = [0] * len(state.colors)
             # state.current_player_index stays the same
             state.current_prompt = ActionPrompt.MOVE_ROBBER
             state.is_moving_knight = True
@@ -304,55 +304,42 @@ def apply_roll(state: State, action: Action, action_record=None):
     return ActionRecord(action=action, result=dices)
 
 
-def normalize_discarded_cards(state: State, action: Action, action_record=None):
+def apply_discard(state: State, action: Action):
     discarded = action.value
-    if discarded is None and action_record is not None:
-        discarded = action_record.result
-
-    if discarded is None:
-        raise ValueError("Discard action requires a resource")
-
-    if isinstance(discarded, (list, tuple)):
-        if len(discarded) != 1:
-            raise ValueError("Discard action must specify exactly 1 resource")
-        return discarded[0]
-
-    return discarded
-
-
-def apply_discard(state: State, action: Action, action_record=None):
-    discarded = normalize_discarded_cards(state, action, action_record)
-    remaining = state.discard_counts[action.color]
-    if remaining <= 0:
-        raise ValueError("Trying to discard more cards than required")
+    player_index = state.color_to_index[action.color]
+    remaining = state.discard_counts[player_index]
+    assert remaining > 0, "Trying to discard when not required"
 
     to_discard = freqdeck_from_listdeck([discarded])
-
     player_freqdeck_subtract(state, action.color, to_discard)
     state.resource_freqdeck = freqdeck_add(state.resource_freqdeck, to_discard)
-    state.discard_counts[action.color] = remaining - 1
+    state.discard_counts[player_index] -= 1
     action = Action(action.color, action.action_type, discarded)
 
-    if state.discard_counts[action.color] > 0:
+    if state.discard_counts[player_index] > 0:
         # state.current_player_index stays the same
         # state.current_prompt stays the same
         pass
     else:
-        discarders_left = [state.discard_counts[color] > 0 for color in state.colors][
-            state.current_player_index + 1 :
-        ]
-        if any(discarders_left):
-            to_skip = discarders_left.index(True)
-            state.current_player_index = state.current_player_index + 1 + to_skip
+        next_discarder_index = next(
+            (
+                i
+                for i in range(state.current_player_index + 1, len(state.colors))
+                if state.discard_counts[i] > 0
+            ),
+            None,
+        )
+        if next_discarder_index is not None:
+            state.current_player_index = next_discarder_index
             # state.current_prompt stays the same
         else:
             state.current_player_index = state.current_turn_index
             state.current_prompt = ActionPrompt.MOVE_ROBBER
             state.is_discarding = False
             state.is_moving_knight = True
-            state.discard_counts = {color: 0 for color in state.colors}
+            state.discard_counts = [0] * len(state.colors)
 
-    return ActionRecord(action=action, result=[discarded])
+    return ActionRecord(action=action, result=discarded)
 
 
 def apply_move_robber(state: State, action: Action, action_record=None):

--- a/catanatron/catanatron/apply_action.py
+++ b/catanatron/catanatron/apply_action.py
@@ -305,33 +305,33 @@ def apply_roll(state: State, action: Action, action_record=None):
 
 
 def normalize_discarded_cards(state: State, action: Action, action_record=None):
-    if action.value is not None:
-        if isinstance(action.value, (list, tuple)):
-            return list(action.value)
-        return [action.value]
+    discarded = action.value
+    if discarded is None and action_record is not None:
+        discarded = action_record.result
 
-    if action_record is not None and action_record.result is not None:
-        if isinstance(action_record.result, (list, tuple)):
-            return list(action_record.result)
-        return [action_record.result]
+    if discarded is None:
+        raise ValueError("Discard action requires a resource")
 
-    hand = player_deck_to_array(state, action.color)
-    return [random.choice(hand)]
+    if isinstance(discarded, (list, tuple)):
+        if len(discarded) != 1:
+            raise ValueError("Discard action must specify exactly 1 resource")
+        return discarded[0]
+
+    return discarded
 
 
 def apply_discard(state: State, action: Action, action_record=None):
     discarded = normalize_discarded_cards(state, action, action_record)
     remaining = state.discard_counts[action.color]
-    if len(discarded) > remaining:
+    if remaining <= 0:
         raise ValueError("Trying to discard more cards than required")
 
-    to_discard = freqdeck_from_listdeck(discarded)
+    to_discard = freqdeck_from_listdeck([discarded])
 
     player_freqdeck_subtract(state, action.color, to_discard)
     state.resource_freqdeck = freqdeck_add(state.resource_freqdeck, to_discard)
-    state.discard_counts[action.color] = remaining - len(discarded)
-    action_value = discarded[0] if len(discarded) == 1 else tuple(discarded)
-    action = Action(action.color, action.action_type, action_value)
+    state.discard_counts[action.color] = remaining - 1
+    action = Action(action.color, action.action_type, discarded)
 
     if state.discard_counts[action.color] > 0:
         # state.current_player_index stays the same
@@ -352,7 +352,7 @@ def apply_discard(state: State, action: Action, action_record=None):
             state.is_moving_knight = True
             state.discard_counts = {color: 0 for color in state.colors}
 
-    return ActionRecord(action=action, result=discarded)
+    return ActionRecord(action=action, result=[discarded])
 
 
 def apply_move_robber(state: State, action: Action, action_record=None):

--- a/catanatron/catanatron/features.py
+++ b/catanatron/catanatron/features.py
@@ -486,7 +486,7 @@ def game_features(game: Game, p0_color: Color):
     features = {
         "BANK_DEV_CARDS": len(game.state.development_listdeck),
         "IS_MOVING_ROBBER": ActionType.MOVE_ROBBER in possibilities,
-        "IS_DISCARDING": ActionType.DISCARD in possibilities,
+        "IS_DISCARDING": ActionType.DISCARD_RESOURCE in possibilities,
     }
     for resource in RESOURCES:
         features[f"BANK_{resource}"] = freqdeck_count(

--- a/catanatron/catanatron/game.py
+++ b/catanatron/catanatron/game.py
@@ -129,11 +129,6 @@ class Game:
             )
             self.playable_actions = generate_playable_actions(self.state)
 
-    def __setstate__(self, state):
-        self.__dict__ = state
-        if not hasattr(self, "playable_actions"):
-            self.playable_actions = generate_playable_actions(self.state)
-
     def play(self, accumulators=[], decide_fn=None):
         """Executes game until a player wins or exceeded TURNS_LIMIT.
 

--- a/catanatron/catanatron/game.py
+++ b/catanatron/catanatron/game.py
@@ -120,6 +120,11 @@ class Game:
             self.state = State(players, catan_map, discard_limit=discard_limit)
             self.playable_actions = generate_playable_actions(self.state)
 
+    def __setstate__(self, state):
+        self.__dict__ = state
+        if not hasattr(self, "playable_actions"):
+            self.playable_actions = generate_playable_actions(self.state)
+
     def play(self, accumulators=[], decide_fn=None):
         """Executes game until a player wins or exceeded TURNS_LIMIT.
 

--- a/catanatron/catanatron/gym/envs/action_space.py
+++ b/catanatron/catanatron/gym/envs/action_space.py
@@ -20,7 +20,7 @@ def get_action_array(
     actions_array = sorted(
         [
             (ActionType.ROLL, None),
-            (ActionType.DISCARD, None),
+            *[(ActionType.DISCARD, resource) for resource in RESOURCES],
             *[
                 (ActionType.BUILD_ROAD, tuple(sorted(edge)))
                 for edge in get_edges(catan_map.land_nodes)

--- a/catanatron/catanatron/gym/envs/action_space.py
+++ b/catanatron/catanatron/gym/envs/action_space.py
@@ -15,6 +15,8 @@ def get_action_array(
     catan_map = build_map(map_type)
     num_nodes = len(catan_map.land_nodes)
 
+    # We sort the actions to ensure a consistent ordering and reproducibility
+    # without sorting, we couldn't get gym usages to be reproducible
     actions_array = sorted(
         [
             (ActionType.ROLL, None),
@@ -67,9 +69,7 @@ def get_action_array(
             ],
             (ActionType.END_TURN, None),
         ],
-        # Preserve historical DISCARD ordering so the rename does not reshuffle
-        # integer action ids for gym consumers.
-        key=lambda action: str(action).replace("DISCARD_RESOURCE", "DISCARD"),
+        key=lambda action: str(action),
     )
     return actions_array
 

--- a/catanatron/catanatron/gym/envs/action_space.py
+++ b/catanatron/catanatron/gym/envs/action_space.py
@@ -17,10 +17,15 @@ def get_action_array(
 
     # We sort the actions to ensure a consistent ordering and reproducibility
     # without sorting, we couldn't get gym usages to be reproducible
+    def action_sort_key(action):
+        # Preserve historical DISCARD ordering so the rename does not reshuffle
+        # integer action ids for gym consumers.
+        return str(action).replace("DISCARD_RESOURCE", "DISCARD")
+
     actions_array = sorted(
         [
             (ActionType.ROLL, None),
-            *[(ActionType.DISCARD, resource) for resource in RESOURCES],
+            *[(ActionType.DISCARD_RESOURCE, resource) for resource in RESOURCES],
             *[
                 (ActionType.BUILD_ROAD, tuple(sorted(edge)))
                 for edge in get_edges(catan_map.land_nodes)
@@ -69,7 +74,7 @@ def get_action_array(
             ],
             (ActionType.END_TURN, None),
         ],
-        key=lambda x: str(x),
+        key=action_sort_key,
     )
     return actions_array
 

--- a/catanatron/catanatron/gym/envs/action_space.py
+++ b/catanatron/catanatron/gym/envs/action_space.py
@@ -15,13 +15,6 @@ def get_action_array(
     catan_map = build_map(map_type)
     num_nodes = len(catan_map.land_nodes)
 
-    # We sort the actions to ensure a consistent ordering and reproducibility
-    # without sorting, we couldn't get gym usages to be reproducible
-    def action_sort_key(action):
-        # Preserve historical DISCARD ordering so the rename does not reshuffle
-        # integer action ids for gym consumers.
-        return str(action).replace("DISCARD_RESOURCE", "DISCARD")
-
     actions_array = sorted(
         [
             (ActionType.ROLL, None),
@@ -74,7 +67,9 @@ def get_action_array(
             ],
             (ActionType.END_TURN, None),
         ],
-        key=action_sort_key,
+        # Preserve historical DISCARD ordering so the rename does not reshuffle
+        # integer action ids for gym consumers.
+        key=lambda action: str(action).replace("DISCARD_RESOURCE", "DISCARD"),
     )
     return actions_array
 

--- a/catanatron/catanatron/gym/envs/catanatron_env.py
+++ b/catanatron/catanatron/gym/envs/catanatron_env.py
@@ -329,9 +329,8 @@ CatanatronEnv.__doc__ += """
      - Float
 
    * - IS_DISCARDING
-     - Whether current player must discard. For now, there is only 1 
-       discarding action (at random), since otherwise action space
-       would explode in size.
+     - Whether current player must discard. Discarding is represented
+       as one action per resource type currently held.
      - 1
      - Boolean
    * - IS_MOVING_ROBBER

--- a/catanatron/catanatron/json.py
+++ b/catanatron/catanatron/json.py
@@ -30,6 +30,15 @@ def action_from_json(data) -> Action:
         if len(resources) not in [1, 2]:
             raise ValueError("Year of Plenty action must have 1 or 2 resources")
         action = Action(color, action_type, resources)
+    elif action_type == ActionType.DISCARD:
+        value = data[2]
+        if isinstance(value, list):
+            if len(value) != 1:
+                raise ValueError(
+                    "Discard action must have 1 resource when encoded as a list"
+                )
+            value = value[0]
+        action = Action(color, action_type, value)
     elif action_type == ActionType.MOVE_ROBBER:
         coordinate, victim = data[2]
         coordinate = tuple(coordinate)

--- a/catanatron/catanatron/json.py
+++ b/catanatron/catanatron/json.py
@@ -30,7 +30,7 @@ def action_from_json(data) -> Action:
         if len(resources) not in [1, 2]:
             raise ValueError("Year of Plenty action must have 1 or 2 resources")
         action = Action(color, action_type, resources)
-    elif action_type == ActionType.DISCARD:
+    elif action_type == ActionType.DISCARD_RESOURCE:
         value = data[2]
         if isinstance(value, list):
             if len(value) != 1:

--- a/catanatron/catanatron/json.py
+++ b/catanatron/catanatron/json.py
@@ -97,6 +97,9 @@ class GameEncoder(json.JSONEncoder):
                 "robber_coordinate": obj.state.board.robber_coordinate,
                 "current_color": obj.state.current_color(),
                 "current_prompt": obj.state.current_prompt,
+                "current_discard_count": obj.state.discard_counts[
+                    obj.state.current_player_index
+                ],
                 "current_playable_actions": obj.playable_actions,
                 "longest_roads_by_player": longest_roads_by_player(obj.state),
                 "winning_color": obj.winning_color(),

--- a/catanatron/catanatron/json.py
+++ b/catanatron/catanatron/json.py
@@ -30,8 +30,6 @@ def action_from_json(data) -> Action:
         if len(resources) not in [1, 2]:
             raise ValueError("Year of Plenty action must have 1 or 2 resources")
         action = Action(color, action_type, resources)
-    elif action_type == ActionType.DISCARD_RESOURCE:
-        action = Action(color, action_type, data[2])
     elif action_type == ActionType.MOVE_ROBBER:
         coordinate, victim = data[2]
         coordinate = tuple(coordinate)

--- a/catanatron/catanatron/json.py
+++ b/catanatron/catanatron/json.py
@@ -31,14 +31,7 @@ def action_from_json(data) -> Action:
             raise ValueError("Year of Plenty action must have 1 or 2 resources")
         action = Action(color, action_type, resources)
     elif action_type == ActionType.DISCARD_RESOURCE:
-        value = data[2]
-        if isinstance(value, list):
-            if len(value) != 1:
-                raise ValueError(
-                    "Discard action must have 1 resource when encoded as a list"
-                )
-            value = value[0]
-        action = Action(color, action_type, value)
+        action = Action(color, action_type, data[2])
     elif action_type == ActionType.MOVE_ROBBER:
         coordinate, victim = data[2]
         coordinate = tuple(coordinate)

--- a/catanatron/catanatron/models/actions.py
+++ b/catanatron/catanatron/models/actions.py
@@ -283,7 +283,7 @@ def discard_possibilities(state: State, color) -> List[Action]:
         return []
 
     return [
-        Action(color, ActionType.DISCARD, resource)
+        Action(color, ActionType.DISCARD_RESOURCE, resource)
         for resource in RESOURCES
         if player_num_resource_cards(state, color, resource) > 0
     ]

--- a/catanatron/catanatron/models/actions.py
+++ b/catanatron/catanatron/models/actions.py
@@ -87,7 +87,7 @@ def generate_playable_actions(state: State) -> List[Action]:
             actions.extend(maritime_trade_possibilities(state, color))
         return actions
     elif action_prompt == ActionPrompt.DISCARD:
-        return discard_possibilities(color)
+        return discard_possibilities(state, color)
     elif action_prompt == ActionPrompt.DECIDE_TRADE:
         actions = [Action(color, ActionType.REJECT_TRADE, state.current_trade)]
 
@@ -245,24 +245,15 @@ def initial_road_possibilities(state, color) -> List[Action]:
     return [Action(color, ActionType.BUILD_ROAD, edge) for edge in buildable_edges]
 
 
-def discard_possibilities(color) -> List[Action]:
-    return [Action(color, ActionType.DISCARD, None)]
-    # TODO: Be robust to high dimensionality of DISCARD
-    # hand = player.resource_deck.to_array()
-    # num_cards = player.resource_deck.num_cards()
-    # num_to_discard = num_cards // 2
+def discard_possibilities(state: State, color) -> List[Action]:
+    if state.discard_counts[color] <= 0:
+        return []
 
-    # num_possibilities = ncr(num_cards, num_to_discard)
-    # if num_possibilities > 100:  # if too many, just take first N
-    #     return [Action(player, ActionType.DISCARD, hand[:num_to_discard])]
-
-    # to_discard = itertools.combinations(hand, num_to_discard)
-    # return list(
-    #     map(
-    #         lambda combination: Action(player, ActionType.DISCARD, combination),
-    #         to_discard,
-    #     )
-    # )
+    return [
+        Action(color, ActionType.DISCARD, resource)
+        for resource in RESOURCES
+        if player_num_resource_cards(state, color, resource) > 0
+    ]
 
 
 def ncr(n, r):

--- a/catanatron/catanatron/models/actions.py
+++ b/catanatron/catanatron/models/actions.py
@@ -279,7 +279,7 @@ def initial_road_possibilities(state, color) -> List[Action]:
 
 
 def discard_possibilities(state: State, color) -> List[Action]:
-    if state.discard_counts[color] <= 0:
+    if state.discard_counts[state.color_to_index[color]] <= 0:
         return []
 
     return [

--- a/catanatron/catanatron/models/enums.py
+++ b/catanatron/catanatron/models/enums.py
@@ -131,7 +131,7 @@ undoing actions to a State.
 
 The "result" field is polymorphic depending on the action_type.
 - ROLL: result is (int, int) 2 dice rolled
-- DISCARD_RESOURCE: result is List[Resource] discarded in this action
+- DISCARD_RESOURCE: result is Resource discarded in this action
 - MOVE_ROBBER: result is card stolen (Resource|None)
 - BUY_DEVELOPMENT_CARD: result is card
 - ...for the rest, result is None since they are deterministic actions

--- a/catanatron/catanatron/models/enums.py
+++ b/catanatron/catanatron/models/enums.py
@@ -75,8 +75,7 @@ class ActionType(Enum):
     ROLL = "ROLL"  # value is None
     MOVE_ROBBER = "MOVE_ROBBER"  # value is (coordinate, Color|None).
 
-    # TODO: None for now to avoid complexity, but should be Resource[].
-    DISCARD = "DISCARD"  # value is None
+    DISCARD = "DISCARD"  # value is Resource
 
     # Building/Buying
     BUILD_ROAD = "BUILD_ROAD"  # value is edge_id
@@ -132,7 +131,7 @@ undoing actions to a State.
 
 The "result" field is polymorphic depending on the action_type.
 - ROLL: result is (int, int) 2 dice rolled
-- DISCARD: result is List[Resource] discarded
+- DISCARD: result is List[Resource] discarded in this action
 - MOVE_ROBBER: result is card stolen (Resource|None)
 - BUY_DEVELOPMENT_CARD: result is card
 - ...for the rest, result is None since they are deterministic actions

--- a/catanatron/catanatron/models/enums.py
+++ b/catanatron/catanatron/models/enums.py
@@ -75,7 +75,7 @@ class ActionType(Enum):
     ROLL = "ROLL"  # value is None
     MOVE_ROBBER = "MOVE_ROBBER"  # value is (coordinate, Color|None).
 
-    DISCARD = "DISCARD"  # value is Resource
+    DISCARD_RESOURCE = "DISCARD_RESOURCE"  # value is Resource
 
     # Building/Buying
     BUILD_ROAD = "BUILD_ROAD"  # value is edge_id
@@ -131,7 +131,7 @@ undoing actions to a State.
 
 The "result" field is polymorphic depending on the action_type.
 - ROLL: result is (int, int) 2 dice rolled
-- DISCARD: result is List[Resource] discarded in this action
+- DISCARD_RESOURCE: result is List[Resource] discarded in this action
 - MOVE_ROBBER: result is card stolen (Resource|None)
 - BUY_DEVELOPMENT_CARD: result is card
 - ...for the rest, result is None since they are deterministic actions

--- a/catanatron/catanatron/players/tree_search_utils.py
+++ b/catanatron/catanatron/players/tree_search_utils.py
@@ -31,7 +31,7 @@ DETERMINISTIC_ACTIONS = set(
         ActionType.PLAY_YEAR_OF_PLENTY,
         ActionType.PLAY_ROAD_BUILDING,
         ActionType.MARITIME_TRADE,
-        ActionType.DISCARD,  # for simplicity... ok if reality is slightly different
+        ActionType.DISCARD_RESOURCE,  # for simplicity... ok if reality is slightly different
         ActionType.PLAY_MONOPOLY,  # for simplicity... we assume good card-counting and bank is visible...
     ]
 )

--- a/catanatron/catanatron/state.py
+++ b/catanatron/catanatron/state.py
@@ -76,7 +76,7 @@ class State:
         current_prompt (ActionPrompt): DEPRECATED. Not needed; use is_initial_build_phase,
             is_moving_knight, etc... instead.
         is_discarding (bool): If current player needs to discard.
-        discard_counts (Dict[Color, int]): Remaining number of cards each player
+        discard_counts (List[int]): Color-index aligned number of cards each player
             must discard in the current discard sequence.
         is_moving_knight (bool): If current player needs to move robber.
         is_road_building (bool): If current player needs to build free roads per Road
@@ -133,7 +133,7 @@ class State:
             self.current_prompt = ActionPrompt.BUILD_INITIAL_SETTLEMENT
             self.is_initial_build_phase = True
             self.is_discarding = False
-            self.discard_counts: Dict[Color, int] = {color: 0 for color in self.colors}
+            self.discard_counts: List[int] = [0] * len(self.colors)
             self.is_moving_knight = False
             self.is_road_building = False
             self.free_roads_available = 0

--- a/catanatron/catanatron/state.py
+++ b/catanatron/catanatron/state.py
@@ -1,7 +1,7 @@
-import random
 import pickle
+import random
 from collections import defaultdict
-from typing import Any, List, Sequence, Tuple, Dict
+from typing import Any, Dict, List, Sequence, Tuple
 
 from catanatron.models.map import BASE_MAP_TEMPLATE, CatanMap
 from catanatron.models.board import Board
@@ -76,6 +76,8 @@ class State:
         current_prompt (ActionPrompt): DEPRECATED. Not needed; use is_initial_build_phase,
             is_moving_knight, etc... instead.
         is_discarding (bool): If current player needs to discard.
+        discard_counts (Dict[Color, int]): Remaining number of cards each player
+            must discard in the current discard sequence.
         is_moving_knight (bool): If current player needs to move robber.
         is_road_building (bool): If current player needs to build free roads per Road
             Building dev card.
@@ -126,6 +128,9 @@ class State:
             self.current_prompt = ActionPrompt.BUILD_INITIAL_SETTLEMENT
             self.is_initial_build_phase = True
             self.is_discarding = False
+            self.discard_counts: Dict[Color, int] = {
+                color: 0 for color in self.colors
+            }
             self.is_moving_knight = False
             self.is_road_building = False
             self.free_roads_available = 0
@@ -133,6 +138,17 @@ class State:
             self.is_resolving_trade = False
             self.current_trade: Tuple = (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
             self.acceptees = tuple(False for _ in self.colors)
+
+    def __setstate__(self, state):
+        self.__dict__ = state
+        if not hasattr(self, "action_records"):
+            self.action_records = []
+        # Migration for discard_counts if it's a list (old format)
+        if hasattr(self, "discard_counts") and isinstance(self.discard_counts, list):
+            self.discard_counts = {
+                color: count
+                for color, count in zip(self.colors, self.discard_counts)
+            }
 
     def current_player(self):
         """Helper for accessing Player instance who should decide next"""
@@ -176,6 +192,7 @@ class State:
         state_copy.current_prompt = self.current_prompt
         state_copy.is_initial_build_phase = self.is_initial_build_phase
         state_copy.is_discarding = self.is_discarding
+        state_copy.discard_counts = self.discard_counts.copy()
         state_copy.is_moving_knight = self.is_moving_knight
         state_copy.is_road_building = self.is_road_building
         state_copy.free_roads_available = self.free_roads_available

--- a/catanatron/catanatron/state.py
+++ b/catanatron/catanatron/state.py
@@ -133,9 +133,8 @@ class State:
             self.current_prompt = ActionPrompt.BUILD_INITIAL_SETTLEMENT
             self.is_initial_build_phase = True
             self.is_discarding = False
-            self.discard_counts: Dict[Color, int] = {
-                color: 0 for color in self.colors
-            }
+            self.discard_counts: Dict[Color, int] = {color: 0 for color in self.colors}
+            self.discard_counts: Dict[Color, int] = {color: 0 for color in self.colors}
             self.is_moving_knight = False
             self.is_road_building = False
             self.free_roads_available = 0
@@ -143,17 +142,6 @@ class State:
             self.is_resolving_trade = False
             self.current_trade: Tuple = (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
             self.acceptees = tuple(False for _ in self.colors)
-
-    def __setstate__(self, state):
-        self.__dict__ = state
-        if not hasattr(self, "action_records"):
-            self.action_records = []
-        # Migration for discard_counts if it's a list (old format)
-        if hasattr(self, "discard_counts") and isinstance(self.discard_counts, list):
-            self.discard_counts = {
-                color: count
-                for color, count in zip(self.colors, self.discard_counts)
-            }
 
     def current_player(self):
         """Helper for accessing Player instance who should decide next"""

--- a/catanatron/catanatron/state.py
+++ b/catanatron/catanatron/state.py
@@ -134,7 +134,6 @@ class State:
             self.is_initial_build_phase = True
             self.is_discarding = False
             self.discard_counts: Dict[Color, int] = {color: 0 for color in self.colors}
-            self.discard_counts: Dict[Color, int] = {color: 0 for color in self.colors}
             self.is_moving_knight = False
             self.is_road_building = False
             self.free_roads_available = 0

--- a/catanatron/catanatron/state_functions.py
+++ b/catanatron/catanatron/state_functions.py
@@ -160,8 +160,6 @@ def get_player_freqdeck(state: State, color):
 
 
 def get_state_index(state: State) -> int:
-    if hasattr(state, "_state_index") and state._state_index is not None:
-        return state._state_index
     return len(state.action_records)
 
 

--- a/catanatron/catanatron/state_functions.py
+++ b/catanatron/catanatron/state_functions.py
@@ -160,6 +160,8 @@ def get_player_freqdeck(state: State, color):
 
 
 def get_state_index(state: State) -> int:
+    if hasattr(state, "_state_index") and state._state_index is not None:
+        return state._state_index
     return len(state.action_records)
 
 

--- a/catanatron/catanatron/web/models.py
+++ b/catanatron/catanatron/web/models.py
@@ -92,4 +92,5 @@ def get_game_state(game_id, state_index=None) -> Game | None:
             abort(404)
     db.session.commit()
     game = pickle.loads(result.pickle_data)  # type: ignore
+    game.state._state_index = result.state_index
     return game

--- a/catanatron/catanatron/web/models.py
+++ b/catanatron/catanatron/web/models.py
@@ -91,6 +91,4 @@ def get_game_state(game_id, state_index=None) -> Game | None:
         if result is None:
             abort(404)
     db.session.commit()
-    game = pickle.loads(result.pickle_data)  # type: ignore
-    game.state._state_index = result.state_index
-    return game
+    return pickle.loads(result.pickle_data)  # type: ignore

--- a/tests/models/test_actions.py
+++ b/tests/models/test_actions.py
@@ -1,5 +1,6 @@
 from catanatron.state import State
 from catanatron.models.actions import (
+    discard_possibilities,
     generate_playable_actions,
     monopoly_possibilities,
     year_of_plenty_possibilities,
@@ -10,6 +11,7 @@ from catanatron.models.actions import (
     maritime_trade_possibilities,
 )
 from catanatron.models.enums import (
+    Action,
     BRICK,
     ORE,
     RESOURCES,
@@ -53,6 +55,20 @@ def test_year_of_plenty_possible_actions_not_enough_cards():
 
 def test_monopoly_possible_actions():
     assert len(monopoly_possibilities(Color.RED)) == len(RESOURCES)
+
+
+def test_discard_possibilities_are_per_resource():
+    player = SimplePlayer(Color.RED)
+    state = State([player])
+    state.discard_counts[player.color] = 2
+
+    player_deck_replenish(state, player.color, WHEAT, 2)
+    player_deck_replenish(state, player.color, BRICK, 1)
+
+    assert discard_possibilities(state, player.color) == [
+        Action(player.color, ActionType.DISCARD, BRICK),
+        Action(player.color, ActionType.DISCARD, WHEAT),
+    ]
 
 
 def test_road_possible_actions():
@@ -173,13 +189,6 @@ def test_initial_placement_possibilities():
     red = SimplePlayer(Color.RED)
     state = State([red])
     assert len(settlement_possibilities(state, Color.RED, True)) == 54
-
-
-# TODO: Forcing random selection to ease dimensionality.
-# def test_discard_possibilities():
-#     player = SimplePlayer(Color.RED)
-#     player_deck_replenish(state, player.color, Resource.WHEAT)
-#     assert len(discard_possibilities(player)) == 70
 
 
 def test_4to1_maritime_trade_possibilities():

--- a/tests/models/test_actions.py
+++ b/tests/models/test_actions.py
@@ -66,8 +66,8 @@ def test_discard_possibilities_are_per_resource():
     player_deck_replenish(state, player.color, BRICK, 1)
 
     assert discard_possibilities(state, player.color) == [
-        Action(player.color, ActionType.DISCARD, BRICK),
-        Action(player.color, ActionType.DISCARD, WHEAT),
+        Action(player.color, ActionType.DISCARD_RESOURCE, BRICK),
+        Action(player.color, ActionType.DISCARD_RESOURCE, WHEAT),
     ]
 
 

--- a/tests/models/test_actions.py
+++ b/tests/models/test_actions.py
@@ -71,6 +71,42 @@ def test_discard_possibilities_are_per_resource():
     ]
 
 
+def test_discard_possibilities_empty_when_player_does_not_need_to_discard():
+    player = SimplePlayer(Color.RED)
+    state = State([player])
+
+    player_deck_replenish(state, player.color, WHEAT, 2)
+    player_deck_replenish(state, player.color, BRICK, 1)
+
+    assert discard_possibilities(state, player.color) == []
+
+
+def test_discard_possibilities_do_not_repeat_same_resource():
+    player = SimplePlayer(Color.RED)
+    state = State([player])
+    state.discard_counts[player.color] = 3
+
+    player_deck_replenish(state, player.color, WHEAT, 3)
+
+    assert discard_possibilities(state, player.color) == [
+        Action(player.color, ActionType.DISCARD_RESOURCE, WHEAT),
+    ]
+
+
+def test_discard_possibilities_include_each_resource_in_resource_order():
+    player = SimplePlayer(Color.RED)
+    state = State([player])
+    state.discard_counts[player.color] = len(RESOURCES)
+
+    for resource in RESOURCES:
+        player_deck_replenish(state, player.color, resource)
+
+    assert discard_possibilities(state, player.color) == [
+        Action(player.color, ActionType.DISCARD_RESOURCE, resource)
+        for resource in RESOURCES
+    ]
+
+
 def test_road_possible_actions():
     player = SimplePlayer(Color.RED)
     state = State([player])

--- a/tests/models/test_actions.py
+++ b/tests/models/test_actions.py
@@ -60,7 +60,7 @@ def test_monopoly_possible_actions():
 def test_discard_possibilities_are_per_resource():
     player = SimplePlayer(Color.RED)
     state = State([player])
-    state.discard_counts[player.color] = 2
+    state.discard_counts[0] = 2
 
     player_deck_replenish(state, player.color, WHEAT, 2)
     player_deck_replenish(state, player.color, BRICK, 1)
@@ -84,7 +84,7 @@ def test_discard_possibilities_empty_when_player_does_not_need_to_discard():
 def test_discard_possibilities_do_not_repeat_same_resource():
     player = SimplePlayer(Color.RED)
     state = State([player])
-    state.discard_counts[player.color] = 3
+    state.discard_counts[0] = 3
 
     player_deck_replenish(state, player.color, WHEAT, 3)
 
@@ -96,7 +96,7 @@ def test_discard_possibilities_do_not_repeat_same_resource():
 def test_discard_possibilities_include_each_resource_in_resource_order():
     player = SimplePlayer(Color.RED)
     state = State([player])
-    state.discard_counts[player.color] = len(RESOURCES)
+    state.discard_counts[0] = len(RESOURCES)
 
     for resource in RESOURCES:
         player_deck_replenish(state, player.color, resource)

--- a/tests/test_accumulators.py
+++ b/tests/test_accumulators.py
@@ -44,7 +44,7 @@ def test_accumulators():
     discard_actions = [
         (i, ar.action)
         for i, ar in enumerate(game.state.action_records)
-        if ar.action.action_type == ActionType.DISCARD
+        if ar.action.action_type == ActionType.DISCARD_RESOURCE
     ]
     for index, action in discard_actions:
         game_snapshot = accumulator.games[index]

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -122,7 +122,9 @@ def test_seven_cards_dont_trigger_discarding(fake_roll_dice):
     assert player_num_resource_cards(game.state, players[1].color) == 7
     game.play_tick()  # should be player 0 rolling.
 
-    assert not any(a.action_type == ActionType.DISCARD for a in game.playable_actions)
+    assert not any(
+        a.action_type == ActionType.DISCARD_RESOURCE for a in game.playable_actions
+    )
 
 
 @patch("catanatron.apply_action.roll_dice")
@@ -140,7 +142,9 @@ def test_rolling_a_seven_triggers_default_discard_limit(fake_roll_dice):
     game.play_tick()  # should be player 0 rolling.
 
     assert game.state.current_color() == players[1].color
-    assert all(a.action_type == ActionType.DISCARD for a in game.playable_actions)
+    assert all(
+        a.action_type == ActionType.DISCARD_RESOURCE for a in game.playable_actions
+    )
 
     for _ in range(original_hand_size // 2):
         assert game.state.current_color() == players[1].color
@@ -190,7 +194,8 @@ def test_all_players_discard_as_needed(fake_roll_dice):
             game.state.current_color() == ordered_player.color
         ):
             assert all(
-                a.action_type == ActionType.DISCARD for a in game.playable_actions
+                a.action_type == ActionType.DISCARD_RESOURCE
+                for a in game.playable_actions
             )
             game.play_tick()
             discard_steps += 1
@@ -216,7 +221,9 @@ def test_discard_is_configurable(fake_roll_dice):
     assert player_num_resource_cards(game.state, players[1].color) == 9
     game.play_tick()  # should be p0 rolling.
 
-    assert not any(a.action_type == ActionType.DISCARD for a in game.playable_actions)
+    assert not any(
+        a.action_type == ActionType.DISCARD_RESOURCE for a in game.playable_actions
+    )
 
 
 @patch("catanatron.apply_action.roll_dice")

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -133,14 +133,20 @@ def test_rolling_a_seven_triggers_default_discard_limit(fake_roll_dice):
 
     until_nine = 9 - player_num_resource_cards(game.state, players[1].color)
     player_deck_replenish(game.state, players[1].color, WHEAT, until_nine)
-    assert player_num_resource_cards(game.state, players[1].color) == 9
+    original_hand_size = player_num_resource_cards(game.state, players[1].color)
+    assert original_hand_size == 9
     game.play_tick()  # should be player 0 rolling.
 
-    assert len(game.playable_actions) == 1
-    assert game.playable_actions == [Action(players[1].color, ActionType.DISCARD, None)]
+    assert game.state.current_color() == players[1].color
+    assert all(a.action_type == ActionType.DISCARD for a in game.playable_actions)
 
-    game.play_tick()
+    for _ in range(original_hand_size // 2):
+        assert game.state.current_color() == players[1].color
+        assert game.state.current_prompt == ActionPrompt.DISCARD
+        game.play_tick()
+
     assert player_num_resource_cards(game.state, players[1].color) == 5
+    assert game.state.current_prompt == ActionPrompt.MOVE_ROBBER
 
 
 @patch("catanatron.apply_action.roll_dice")
@@ -175,34 +181,21 @@ def test_all_players_discard_as_needed(fake_roll_dice):
 
     # the following assumes, no matter who rolled 7, asking players
     #   to discard, happens in original seating-order.
-    assert len(game.playable_actions) == 1
-    assert game.playable_actions == [
-        Action(ordered_players[0].color, ActionType.DISCARD, None)
-    ]
+    for ordered_player in ordered_players:
+        assert game.state.current_color() == ordered_player.color
+        discard_steps = 0
+        while game.state.current_prompt == ActionPrompt.DISCARD and (
+            game.state.current_color() == ordered_player.color
+        ):
+            assert all(
+                a.action_type == ActionType.DISCARD for a in game.playable_actions
+            )
+            game.play_tick()
+            discard_steps += 1
 
-    game.play_tick()  # p0 discards, places p1 in line to discard
-    assert player_num_resource_cards(game.state, ordered_players[0].color) == 5
-    assert len(game.playable_actions) == 1
-    assert game.playable_actions == [
-        Action(ordered_players[1].color, ActionType.DISCARD, None)
-    ]
+        assert discard_steps == 4
+        assert player_num_resource_cards(game.state, ordered_player.color) == 5
 
-    game.play_tick()
-    assert player_num_resource_cards(game.state, ordered_players[1].color) == 5
-    assert len(game.playable_actions) == 1
-    assert game.playable_actions == [
-        Action(ordered_players[2].color, ActionType.DISCARD, None)
-    ]
-
-    game.play_tick()
-    assert player_num_resource_cards(game.state, ordered_players[2].color) == 5
-    assert len(game.playable_actions) == 1
-    assert game.playable_actions == [
-        Action(ordered_players[3].color, ActionType.DISCARD, None)
-    ]
-
-    game.play_tick()  # p3 discards, game goes back to p1 moving robber
-    assert player_num_resource_cards(game.state, ordered_players[3].color) == 5
     assert game.state.is_moving_knight
     assert all(a.color == ordered_players[1].color for a in game.playable_actions)
     assert all(a.action_type == ActionType.MOVE_ROBBER for a in game.playable_actions)
@@ -221,7 +214,7 @@ def test_discard_is_configurable(fake_roll_dice):
     assert player_num_resource_cards(game.state, players[1].color) == 9
     game.play_tick()  # should be p0 rolling.
 
-    assert game.playable_actions != [Action(players[1].color, ActionType.DISCARD, None)]
+    assert not any(a.action_type == ActionType.DISCARD for a in game.playable_actions)
 
 
 @patch("catanatron.apply_action.roll_dice")

--- a/tests/test_gym.py
+++ b/tests/test_gym.py
@@ -213,7 +213,7 @@ def test_action_space_conversion_roundtrip():
     # RESOURCES = ['WOOD', 'BRICK', 'SHEEP', 'WHEAT', 'ORE']
     test_actions = [
         Action(Color.BLUE, ActionType.ROLL, None),
-        Action(Color.BLUE, ActionType.DISCARD, WHEAT),
+        Action(Color.BLUE, ActionType.DISCARD_RESOURCE, WHEAT),
         Action(Color.BLUE, ActionType.BUILD_SETTLEMENT, 10),
         Action(Color.BLUE, ActionType.BUILD_CITY, 5),
         Action(Color.BLUE, ActionType.BUILD_ROAD, (0, 1)),

--- a/tests/test_gym.py
+++ b/tests/test_gym.py
@@ -281,4 +281,4 @@ def test_gym_reproducibility():
     game_json = json.loads(json.dumps(game, cls=GameEncoder))
     env.close()
 
-    assert game_json["state_index"] == 146
+    assert game_json["state_index"] == 125

--- a/tests/test_gym.py
+++ b/tests/test_gym.py
@@ -213,7 +213,7 @@ def test_action_space_conversion_roundtrip():
     # RESOURCES = ['WOOD', 'BRICK', 'SHEEP', 'WHEAT', 'ORE']
     test_actions = [
         Action(Color.BLUE, ActionType.ROLL, None),
-        Action(Color.BLUE, ActionType.DISCARD, None),
+        Action(Color.BLUE, ActionType.DISCARD, WHEAT),
         Action(Color.BLUE, ActionType.BUILD_SETTLEMENT, 10),
         Action(Color.BLUE, ActionType.BUILD_CITY, 5),
         Action(Color.BLUE, ActionType.BUILD_ROAD, (0, 1)),
@@ -281,4 +281,4 @@ def test_gym_reproducibility():
     game_json = json.loads(json.dumps(game, cls=GameEncoder))
     env.close()
 
-    assert game_json["state_index"] == 126
+    assert game_json["state_index"] == 124

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -53,10 +53,10 @@ def test_action_from_json_play_year_of_plenty_one_resource():
 
 
 def test_action_from_json_discard():
-    data = ["BLUE", "DISCARD", WOOD]
+    data = ["BLUE", "DISCARD_RESOURCE", WOOD]
     action = action_from_json(data)
     assert action.color == Color.BLUE
-    assert action.action_type == ActionType.DISCARD
+    assert action.action_type == ActionType.DISCARD_RESOURCE
     assert action.value == WOOD
 
 

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -52,6 +52,14 @@ def test_action_from_json_play_year_of_plenty_one_resource():
     assert action.value == (SHEEP,)
 
 
+def test_action_from_json_discard():
+    data = ["BLUE", "DISCARD", WOOD]
+    action = action_from_json(data)
+    assert action.color == Color.BLUE
+    assert action.action_type == ActionType.DISCARD
+    assert action.value == WOOD
+
+
 def test_action_from_json_play_year_of_plenty_invalid():
     data = ["WHITE", "PLAY_YEAR_OF_PLENTY", [WOOD, BRICK, SHEEP]]
     with pytest.raises(

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -60,12 +60,6 @@ def test_action_from_json_discard():
     assert action.value == WOOD
 
 
-def test_action_from_json_discard_rejects_list_value():
-    data = ["BLUE", "DISCARD_RESOURCE", [WOOD]]
-    with pytest.raises(ValueError, match="Discard action must have 1 resource"):
-        action_from_json(data)
-
-
 def test_action_from_json_play_year_of_plenty_invalid():
     data = ["WHITE", "PLAY_YEAR_OF_PLENTY", [WOOD, BRICK, SHEEP]]
     with pytest.raises(

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -60,6 +60,12 @@ def test_action_from_json_discard():
     assert action.value == WOOD
 
 
+def test_action_from_json_discard_rejects_list_value():
+    data = ["BLUE", "DISCARD_RESOURCE", [WOOD]]
+    with pytest.raises(ValueError, match="Discard action must have 1 resource"):
+        action_from_json(data)
+
+
 def test_action_from_json_play_year_of_plenty_invalid():
     data = ["WHITE", "PLAY_YEAR_OF_PLENTY", [WOOD, BRICK, SHEEP]]
     with pytest.raises(

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -225,14 +225,14 @@ def test_discard_sequence_tracks_original_hand_size():
     player_deck_replenish(state, color, BRICK, 1)
     player_deck_replenish(state, color, WHEAT, 3)
 
-    apply_action(state, Action(color, ActionType.DISCARD, BRICK))
+    apply_action(state, Action(color, ActionType.DISCARD_RESOURCE, BRICK))
     assert state.current_color() == color
     assert state.is_discarding
     assert state.discard_counts[color] == 3
 
-    apply_action(state, Action(color, ActionType.DISCARD, WHEAT))
-    apply_action(state, Action(color, ActionType.DISCARD, WHEAT))
-    apply_action(state, Action(color, ActionType.DISCARD, WHEAT))
+    apply_action(state, Action(color, ActionType.DISCARD_RESOURCE, WHEAT))
+    apply_action(state, Action(color, ActionType.DISCARD_RESOURCE, WHEAT))
+    apply_action(state, Action(color, ActionType.DISCARD_RESOURCE, WHEAT))
     assert not state.is_discarding
     assert state.is_moving_knight
     assert state.current_player_index == turn_player_index

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -208,3 +208,31 @@ def test_sequence():
     p0_color = state.colors[0]
     assert state.current_prompt == ActionPrompt.BUILD_INITIAL_SETTLEMENT
     apply_action(state, Action(p0_color, ActionType.BUILD_SETTLEMENT, 0))
+
+
+def test_discard_sequence_tracks_original_hand_size():
+    players = [SimplePlayer(Color.RED), SimplePlayer(Color.BLUE)]
+    state = State(players)
+    color = players[0].color
+    current_player_index = state.colors.index(color)
+    turn_player_index = state.colors.index(players[1].color)
+
+    state.current_turn_index = turn_player_index
+    state.current_player_index = current_player_index
+    state.current_prompt = ActionPrompt.DISCARD
+    state.is_discarding = True
+    state.discard_counts[color] = 4
+    player_deck_replenish(state, color, BRICK, 1)
+    player_deck_replenish(state, color, WHEAT, 3)
+
+    apply_action(state, Action(color, ActionType.DISCARD, BRICK))
+    assert state.current_color() == color
+    assert state.is_discarding
+    assert state.discard_counts[color] == 3
+
+    apply_action(state, Action(color, ActionType.DISCARD, WHEAT))
+    apply_action(state, Action(color, ActionType.DISCARD, WHEAT))
+    apply_action(state, Action(color, ActionType.DISCARD, WHEAT))
+    assert not state.is_discarding
+    assert state.is_moving_knight
+    assert state.current_player_index == turn_player_index

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -221,14 +221,14 @@ def test_discard_sequence_tracks_original_hand_size():
     state.current_player_index = current_player_index
     state.current_prompt = ActionPrompt.DISCARD
     state.is_discarding = True
-    state.discard_counts[color] = 4
+    state.discard_counts[current_player_index] = 4
     player_deck_replenish(state, color, BRICK, 1)
     player_deck_replenish(state, color, WHEAT, 3)
 
     apply_action(state, Action(color, ActionType.DISCARD_RESOURCE, BRICK))
     assert state.current_color() == color
     assert state.is_discarding
-    assert state.discard_counts[color] == 3
+    assert state.discard_counts[current_player_index] == 3
 
     apply_action(state, Action(color, ActionType.DISCARD_RESOURCE, WHEAT))
     apply_action(state, Action(color, ActionType.DISCARD_RESOURCE, WHEAT))
@@ -236,3 +236,35 @@ def test_discard_sequence_tracks_original_hand_size():
     assert not state.is_discarding
     assert state.is_moving_knight
     assert state.current_player_index == turn_player_index
+
+
+def test_discard_sequence_advances_to_next_discarder():
+    players = [
+        SimplePlayer(Color.RED),
+        SimplePlayer(Color.BLUE),
+        SimplePlayer(Color.WHITE),
+    ]
+    state = State(players)
+    current_color = players[0].color
+    next_color = players[2].color
+    current_player_index = state.colors.index(current_color)
+    next_player_index = state.colors.index(next_color)
+
+    state.current_turn_index = 1
+    state.current_player_index = current_player_index
+    state.current_prompt = ActionPrompt.DISCARD
+    state.is_discarding = True
+    state.discard_counts[current_player_index] = 1
+    state.discard_counts[next_player_index] = 2
+
+    player_deck_replenish(state, current_color, BRICK, 1)
+
+    apply_action(
+        state,
+        Action(current_color, ActionType.DISCARD_RESOURCE, BRICK),
+    )
+
+    assert state.current_player_index == next_player_index
+    assert state.current_color() == next_color
+    assert state.is_discarding
+    assert state.current_prompt == ActionPrompt.DISCARD

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -24,7 +24,7 @@ def build_initial_placements(
 def advance_to_play_turn(game: Game):
     game.execute(Action(game.state.current_color(), ActionType.ROLL, None))
     while game.playable_actions[0].action_type in [
-        ActionType.DISCARD,
+        ActionType.DISCARD_RESOURCE,
         ActionType.MOVE_ROBBER,
     ]:
         game.execute(game.playable_actions[0])

--- a/tests/web/test_api.py
+++ b/tests/web/test_api.py
@@ -140,6 +140,24 @@ def test_post_action_bot_turn(client):
     assert len(data_after["action_records"]) > len(data_before["action_records"])
 
 
+def test_repeated_bot_actions_advance_latest_state(client):
+    """Latest state should keep advancing across persisted bot turns."""
+    post_response = client.post("/api/games", json={"players": ["RANDOM", "RANDOM"]})
+    assert post_response.status_code == 200
+    game_id = json.loads(post_response.data)["game_id"]
+
+    latest_before = json.loads(client.get(f"/api/games/{game_id}/states/latest").data)
+    first_tick = json.loads(client.post(f"/api/games/{game_id}/actions", json={}).data)
+    second_tick = json.loads(client.post(f"/api/games/{game_id}/actions", json={}).data)
+    latest_after = json.loads(client.get(f"/api/games/{game_id}/states/latest").data)
+
+    assert first_tick["state_index"] == latest_before["state_index"] + 1
+    assert second_tick["state_index"] == first_tick["state_index"] + 1
+    assert len(second_tick["action_records"]) == len(first_tick["action_records"]) + 1
+    assert latest_after["state_index"] == second_tick["state_index"]
+    assert latest_after["action_records"] == second_tick["action_records"]
+
+
 def test_mcts_analysis_endpoint(client):
     """Test the MCTS analysis endpoint."""
     post_response = client.post("/api/games", json={"players": ["RANDOM", "RANDOM"]})

--- a/ui/src/components/DiscardPlannerDialog.scss
+++ b/ui/src/components/DiscardPlannerDialog.scss
@@ -1,6 +1,6 @@
 @use "../variables.scss";
 
-.resource-selector {
+.discard-planner {
   .MuiPaper-root {
     background-color: #1a1a1a;
     color: #e0e0e0;
@@ -22,6 +22,28 @@
     padding: 20px;
   }
 
+  .discard-note {
+    margin-top: 4px;
+  }
+
+  .discard-summary {
+    padding-top: 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    margin-bottom: 16px;
+  }
+
+  .selected-discard-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+
+  .selected-discard-chip {
+    text-transform: none;
+  }
+
   .resource-grid {
     display: grid;
     grid-template-columns: repeat(2, 1fr);
@@ -33,7 +55,7 @@
   }
 
   .resource-button {
-    height: 40px;
+    min-height: 54px;
     font-size: 0.9rem;
     text-transform: none;
     background-color: #2a2a2a;
@@ -68,9 +90,9 @@
       font-weight: bold;
     }
 
-    .plus {
-      color: #ffffff;
-      margin: 0 4px;
+    .resource-meta {
+      color: #c7c7c7;
+      font-size: 0.75rem;
     }
   }
 
@@ -87,5 +109,9 @@
     &:hover {
       background-color: rgba(0, 153, 255, 0.1);
     }
+  }
+
+  .clear-button {
+    color: #c7c7c7;
   }
 }

--- a/ui/src/components/DiscardPlannerDialog.tsx
+++ b/ui/src/components/DiscardPlannerDialog.tsx
@@ -1,0 +1,160 @@
+import React from "react";
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Typography,
+} from "@mui/material";
+import type { ResourceCard } from "../utils/api.types";
+import "./DiscardPlannerDialog.scss";
+
+type DiscardResourceCounts = Partial<Record<ResourceCard, number>>;
+
+type DiscardPlannerDialogProps = {
+  open: boolean;
+  onClose: () => void;
+  onConfirm: (resources: ResourceCard[]) => void;
+  remainingDiscardCount: number;
+  discardResourceCounts: DiscardResourceCounts;
+  submitting?: boolean;
+};
+
+const RESOURCE_ORDER: ResourceCard[] = [
+  "WOOD",
+  "BRICK",
+  "SHEEP",
+  "WHEAT",
+  "ORE",
+];
+
+export default function DiscardPlannerDialog({
+  open,
+  onClose,
+  onConfirm,
+  remainingDiscardCount,
+  discardResourceCounts,
+  submitting = false,
+}: DiscardPlannerDialogProps) {
+  const [discardSelections, setDiscardSelections] = React.useState<ResourceCard[]>(
+    [],
+  );
+
+  React.useEffect(() => {
+    if (!open) {
+      setDiscardSelections([]);
+    }
+  }, [open]);
+
+  const selectedCount = discardSelections.length;
+  const selectedResourceCount = (resource: ResourceCard) =>
+    discardSelections.filter((selection) => selection === resource).length;
+  const canSelectResource = (resource: ResourceCard) => {
+    const availableCount = discardResourceCounts[resource] ?? 0;
+    return (
+      selectedCount < remainingDiscardCount &&
+      selectedResourceCount(resource) < availableCount
+    );
+  };
+  const addDiscardSelection = (resource: ResourceCard) => {
+    if (!canSelectResource(resource) || submitting) {
+      return;
+    }
+    setDiscardSelections((current) => [...current, resource]);
+  };
+  const removeDiscardSelection = (resource: ResourceCard) => {
+    setDiscardSelections((current) => {
+      const index = current.lastIndexOf(resource);
+      if (index === -1) {
+        return current;
+      }
+      return [...current.slice(0, index), ...current.slice(index + 1)];
+    });
+  };
+  const groupedDiscardSelections = RESOURCE_ORDER.map((resource) => ({
+    resource,
+    count: selectedResourceCount(resource),
+  })).filter(({ count }) => count > 0);
+
+  return (
+    <Dialog
+      open={open}
+      onClose={submitting ? undefined : onClose}
+      className="discard-planner"
+      maxWidth="xs"
+      fullWidth
+    >
+      <DialogTitle>
+        Select Your Discards
+        <Typography variant="body2" className="discard-note">
+          {selectedCount === 0
+            ? `Choose ${remainingDiscardCount} card${remainingDiscardCount === 1 ? "" : "s"}.`
+            : `${selectedCount} of ${remainingDiscardCount} selected.`}
+        </Typography>
+      </DialogTitle>
+      <DialogContent>
+        <div className="discard-summary">
+          {groupedDiscardSelections.length > 0 && (
+            <div className="selected-discard-list">
+              {groupedDiscardSelections.map(({ resource, count }) => (
+                <Button
+                  key={resource}
+                  variant="outlined"
+                  className="selected-discard-chip"
+                  onClick={() => removeDiscardSelection(resource)}
+                  disabled={submitting}
+                >
+                  {resource} x{count}
+                </Button>
+              ))}
+            </div>
+          )}
+        </div>
+        <div className="resource-grid">
+          {RESOURCE_ORDER.filter((resource) => discardResourceCounts[resource] != null).map(
+            (resource) => (
+              <Button
+                key={resource}
+                variant="contained"
+                className="resource-button"
+                onClick={() => addDiscardSelection(resource)}
+                disabled={submitting || !canSelectResource(resource)}
+              >
+                <Typography variant="body2">
+                  <span className={`resource-name ${resource.toLowerCase()}`}>
+                    {resource}
+                  </span>
+                  <br />
+                  <span className="resource-meta">
+                    {selectedResourceCount(resource)}/
+                    {discardResourceCounts[resource]} selected
+                  </span>
+                </Typography>
+              </Button>
+            ),
+          )}
+        </div>
+      </DialogContent>
+      <DialogActions>
+        <Button
+          onClick={() => setDiscardSelections([])}
+          className="clear-button"
+          disabled={submitting || selectedCount === 0}
+        >
+          Clear
+        </Button>
+        <Button onClick={onClose} className="cancel-button" disabled={submitting}>
+          Cancel
+        </Button>
+        <Button
+          variant="contained"
+          onClick={() => onConfirm(discardSelections)}
+          disabled={submitting || selectedCount !== remainingDiscardCount}
+        >
+          Confirm
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/ui/src/components/LeftDrawer.tsx
+++ b/ui/src/components/LeftDrawer.tsx
@@ -34,11 +34,17 @@ function DrawerContent({ gameState }: { gameState: GameState }) {
     <>
       {playerSections}
       <div className="log">
-        {gameState.action_records?.slice().reverse().map((actionRecord, i) => (
-          <div key={i} className={cn("action foreground", actionRecord[0][0])}>
-            {humanizeActionRecord(gameState, actionRecord)}
-          </div>
-        ))}
+        {gameState.action_records
+          .slice()
+          .reverse()
+          .map((actionRecord, i) => (
+            <div
+              key={i}
+              className={cn("action foreground", actionRecord[0][0])}
+            >
+              {humanizeActionRecord(gameState, actionRecord)}
+            </div>
+          ))}
       </div>
     </>
   );
@@ -56,7 +62,7 @@ export default function LeftDrawer() {
 
       dispatch({ type: ACTIONS.SET_LEFT_DRAWER_OPENED, data: true });
     },
-    [dispatch]
+    [dispatch],
   );
   const closeLeftDrawer = useCallback(
     (event: InteractionEvent) => {
@@ -66,7 +72,7 @@ export default function LeftDrawer() {
 
       dispatch({ type: ACTIONS.SET_LEFT_DRAWER_OPENED, data: false });
     },
-    [dispatch]
+    [dispatch],
   );
 
   return (

--- a/ui/src/components/LeftDrawer.tsx
+++ b/ui/src/components/LeftDrawer.tsx
@@ -6,7 +6,7 @@ import Drawer from "@mui/material/Drawer";
 
 import Hidden from "./Hidden";
 import PlayerStateBox from "./PlayerStateBox";
-import { humanizeActionRecord } from "../utils/promptUtils";
+import { humanizeAction, humanizeActionRecord } from "../utils/promptUtils";
 import { store } from "../store";
 import ACTIONS from "../actions";
 import { playerKey } from "../utils/stateUtils";
@@ -35,16 +35,22 @@ function DrawerContent({ gameState }: { gameState: GameState }) {
       {playerSections}
       <div className="log">
         {gameState.action_records
-          .slice()
-          .reverse()
-          .map((actionRecord, i) => (
-            <div
-              key={i}
-              className={cn("action foreground", actionRecord[0][0])}
-            >
-              {humanizeActionRecord(gameState, actionRecord)}
-            </div>
-          ))}
+          ? gameState.action_records
+              .slice()
+              .reverse()
+              .map((actionRecord, i) => (
+                <div
+                  key={i}
+                  className={cn("action foreground", actionRecord[0][0])}
+                >
+                  {humanizeActionRecord(gameState, actionRecord)}
+                </div>
+              ))
+          : gameState.actions?.slice().reverse().map((action, i) => (
+              <div key={i} className={cn("action foreground", action[0])}>
+                {humanizeAction(gameState, action)}
+              </div>
+            ))}
       </div>
     </>
   );

--- a/ui/src/components/LeftDrawer.tsx
+++ b/ui/src/components/LeftDrawer.tsx
@@ -6,7 +6,7 @@ import Drawer from "@mui/material/Drawer";
 
 import Hidden from "./Hidden";
 import PlayerStateBox from "./PlayerStateBox";
-import { humanizeAction, humanizeActionRecord } from "../utils/promptUtils";
+import { humanizeActionRecord } from "../utils/promptUtils";
 import { store } from "../store";
 import ACTIONS from "../actions";
 import { playerKey } from "../utils/stateUtils";
@@ -34,23 +34,11 @@ function DrawerContent({ gameState }: { gameState: GameState }) {
     <>
       {playerSections}
       <div className="log">
-        {gameState.action_records
-          ? gameState.action_records
-              .slice()
-              .reverse()
-              .map((actionRecord, i) => (
-                <div
-                  key={i}
-                  className={cn("action foreground", actionRecord[0][0])}
-                >
-                  {humanizeActionRecord(gameState, actionRecord)}
-                </div>
-              ))
-          : gameState.actions?.slice().reverse().map((action, i) => (
-              <div key={i} className={cn("action foreground", action[0])}>
-                {humanizeAction(gameState, action)}
-              </div>
-            ))}
+        {gameState.action_records?.slice().reverse().map((actionRecord, i) => (
+          <div key={i} className={cn("action foreground", actionRecord[0][0])}>
+            {humanizeActionRecord(gameState, actionRecord)}
+          </div>
+        ))}
       </div>
     </>
   );

--- a/ui/src/components/ResourceSelector.scss
+++ b/ui/src/components/ResourceSelector.scss
@@ -23,10 +23,11 @@
   }
 
   .resource-grid {
+    padding-top: 20px;
     display: grid;
     grid-template-columns: repeat(2, 1fr);
     gap: 12px;
-    
+
     @media (max-width: variables.$sm-breakpoint) {
       grid-template-columns: 1fr;
     }
@@ -48,11 +49,21 @@
       background-color: #222;
     }
 
-    .wood { color: #009b00; }
-    .brick { color: #ff0000; }
-    .wheat { color: #ba9202; }
-    .sheep { color: #3eda58; }
-    .ore { color: #b0b0b0; }
+    .wood {
+      color: #009b00;
+    }
+    .brick {
+      color: #ff0000;
+    }
+    .wheat {
+      color: #ba9202;
+    }
+    .sheep {
+      color: #3eda58;
+    }
+    .ore {
+      color: #b0b0b0;
+    }
 
     .resource-name {
       font-weight: bold;
@@ -73,7 +84,7 @@
   .cancel-button {
     color: #0099ff;
     font-weight: bold;
-    
+
     &:hover {
       background-color: rgba(0, 153, 255, 0.1);
     }

--- a/ui/src/components/ResourceSelector.tsx
+++ b/ui/src/components/ResourceSelector.tsx
@@ -17,35 +17,31 @@ type ResourceSelectorProps = {
   onClose: () => void;
   onSelect: (option: SelectorOption) => void;
   options: SelectorOption[];
-  mode: "discard" | "monopoly" | "yearOfPlenty";
+  mode: "monopoly" | "yearOfPlenty";
 };
 
-const ResourceSelector = ({
+const RESOURCE_ORDER: ResourceCard[] = [
+  "WOOD",
+  "BRICK",
+  "SHEEP",
+  "WHEAT",
+  "ORE",
+];
+
+export default function ResourceSelector({
   open,
   onClose,
   options,
   onSelect,
   mode,
-}: ResourceSelectorProps) => {
-  const resourceOrder: ResourceCard[] = [
-    "WOOD",
-    "BRICK",
-    "SHEEP",
-    "WHEAT",
-    "ORE",
-  ];
+}: ResourceSelectorProps) {
   const isSingleResourceOption = (
     option: SelectorOption,
   ): option is ResourceCard => !Array.isArray(option);
 
   const sortedOptions = React.useMemo(() => {
     if (mode === "monopoly") {
-      return resourceOrder;
-    }
-    if (mode === "discard") {
-      return options
-        .filter(isSingleResourceOption)
-        .sort((a, b) => resourceOrder.indexOf(a) - resourceOrder.indexOf(b));
+      return RESOURCE_ORDER;
     }
 
     const yearOfPlentyOptions = options.filter(
@@ -63,12 +59,12 @@ const ResourceSelector = ({
       const bFirstResource = b[0];
       if (aFirstResource !== bFirstResource) {
         return (
-          resourceOrder.indexOf(aFirstResource) -
-          resourceOrder.indexOf(bFirstResource)
+          RESOURCE_ORDER.indexOf(aFirstResource) -
+          RESOURCE_ORDER.indexOf(bFirstResource)
         );
       }
       if (a.length === 2 && b.length === 2) {
-        return resourceOrder.indexOf(a[1]) - resourceOrder.indexOf(b[1]);
+        return RESOURCE_ORDER.indexOf(a[1]) - RESOURCE_ORDER.indexOf(b[1]);
       }
       return a.length === 1 ? 1 : -1;
     });
@@ -91,15 +87,14 @@ const ResourceSelector = ({
           <span className="plus">x1</span>
         </>
       );
-    } else {
-      return (
-        <>
-          {getResourceSpan(option[0])}
-          <span className="plus">+</span>
-          {getResourceSpan(option[1])}
-        </>
-      );
     }
+    return (
+      <>
+        {getResourceSpan(option[0])}
+        <span className="plus">+</span>
+        {getResourceSpan(option[1])}
+      </>
+    );
   };
 
   return (
@@ -111,16 +106,9 @@ const ResourceSelector = ({
       fullWidth
     >
       <DialogTitle>
-        {mode === "discard"
-          ? "Select Resource to Discard"
-          : mode === "monopoly"
-            ? "Select Resource to Monopolize"
-            : "Select Resources for Year of Plenty"}
-        {mode === "discard" && (
-          <Typography variant="body2" className="discard-note">
-            (Discards happen one card at a time)
-          </Typography>
-        )}
+        {mode === "monopoly"
+          ? "Select Resource to Monopolize"
+          : "Select Resources for Year of Plenty"}
       </DialogTitle>
       <DialogContent>
         <div className="resource-grid">
@@ -145,6 +133,4 @@ const ResourceSelector = ({
       </DialogActions>
     </Dialog>
   );
-};
-
-export default ResourceSelector;
+}

--- a/ui/src/components/ResourceSelector.tsx
+++ b/ui/src/components/ResourceSelector.tsx
@@ -10,12 +10,14 @@ import {
 import "./ResourceSelector.scss";
 import type { ResourceCard } from "../utils/api.types";
 
+type SelectorOption = ResourceCard | ResourceCard[];
+
 type ResourceSelectorProps = {
   open: boolean;
   onClose: () => void;
-  onSelect: (option: ResourceCard | ResourceCard[]) => void;
-  options: ResourceCard[][]; // this is only used when mode == "yearOfPlenty"
-  mode: "monopoly" | "yearOfPlenty";
+  onSelect: (option: SelectorOption) => void;
+  options: SelectorOption[];
+  mode: "discard" | "monopoly" | "yearOfPlenty";
 };
 
 const ResourceSelector = ({
@@ -25,23 +27,36 @@ const ResourceSelector = ({
   onSelect,
   mode,
 }: ResourceSelectorProps) => {
-  const sortedOptions = React.useMemo(() => {
-    const resourceOrder: ResourceCard[] = [
-      "WOOD",
-      "BRICK",
-      "SHEEP",
-      "WHEAT",
-      "ORE",
-    ];
+  const resourceOrder: ResourceCard[] = [
+    "WOOD",
+    "BRICK",
+    "SHEEP",
+    "WHEAT",
+    "ORE",
+  ];
+  const isSingleResourceOption = (
+    option: SelectorOption
+  ): option is ResourceCard => !Array.isArray(option);
 
+  const sortedOptions = React.useMemo(() => {
     if (mode === "monopoly") {
       return resourceOrder;
     }
+    if (mode === "discard") {
+      return options
+        .filter(isSingleResourceOption)
+        .sort((a, b) => resourceOrder.indexOf(a) - resourceOrder.indexOf(b));
+    }
 
-    const hasDoubleOptions = options.some((option) => option.length === 2);
+    const yearOfPlentyOptions = options.filter(
+      (option): option is ResourceCard[] => Array.isArray(option)
+    );
+    const hasDoubleOptions = yearOfPlentyOptions.some(
+      (option) => option.length === 2
+    );
     const filteredOptions = hasDoubleOptions
-      ? options.filter((option) => option.length === 2)
-      : options;
+      ? yearOfPlentyOptions.filter((option) => option.length === 2)
+      : yearOfPlentyOptions;
 
     return filteredOptions.sort((a: ResourceCard[], b: ResourceCard[]) => {
       const aFirstResource = a[0];
@@ -65,13 +80,11 @@ const ResourceSelector = ({
     </span>
   );
 
-  const isMonopolyOption = (
-    option: ResourceCard | ResourceCard[]
-  ): option is ResourceCard => mode === "monopoly" && !!option;
-  const optionToResourceSpan = (option: ResourceCard | ResourceCard[]) => {
-    if (isMonopolyOption(option)) {
+  const optionToResourceSpan = (option: SelectorOption) => {
+    if (isSingleResourceOption(option)) {
       return getResourceSpan(option);
-    } else if (option.length === 1) {
+    }
+    if (option.length === 1) {
       return (
         <>
           {getResourceSpan(option[0])}
@@ -98,7 +111,9 @@ const ResourceSelector = ({
       fullWidth
     >
       <DialogTitle>
-        {mode === "monopoly"
+        {mode === "discard"
+          ? "Select Resource to Discard"
+          : mode === "monopoly"
           ? "Select Resource to Monopolize"
           : "Select Resources for Year of Plenty"}
       </DialogTitle>

--- a/ui/src/components/ResourceSelector.tsx
+++ b/ui/src/components/ResourceSelector.tsx
@@ -35,7 +35,7 @@ const ResourceSelector = ({
     "ORE",
   ];
   const isSingleResourceOption = (
-    option: SelectorOption
+    option: SelectorOption,
   ): option is ResourceCard => !Array.isArray(option);
 
   const sortedOptions = React.useMemo(() => {
@@ -49,10 +49,10 @@ const ResourceSelector = ({
     }
 
     const yearOfPlentyOptions = options.filter(
-      (option): option is ResourceCard[] => Array.isArray(option)
+      (option): option is ResourceCard[] => Array.isArray(option),
     );
     const hasDoubleOptions = yearOfPlentyOptions.some(
-      (option) => option.length === 2
+      (option) => option.length === 2,
     );
     const filteredOptions = hasDoubleOptions
       ? yearOfPlentyOptions.filter((option) => option.length === 2)
@@ -114,8 +114,13 @@ const ResourceSelector = ({
         {mode === "discard"
           ? "Select Resource to Discard"
           : mode === "monopoly"
-          ? "Select Resource to Monopolize"
-          : "Select Resources for Year of Plenty"}
+            ? "Select Resource to Monopolize"
+            : "Select Resources for Year of Plenty"}
+        {mode === "discard" && (
+          <Typography variant="body2" className="discard-note">
+            (Discards happen one card at a time)
+          </Typography>
+        )}
       </DialogTitle>
       <DialogContent>
         <div className="resource-grid">

--- a/ui/src/components/Snackbar.tsx
+++ b/ui/src/components/Snackbar.tsx
@@ -1,46 +1,40 @@
 import { IconButton } from "@mui/material";
 import CloseIcon from "@mui/icons-material/Close";
 import type { GameState } from "../utils/api.types";
-import { latestActionText } from "../utils/promptUtils";
+import { humanizeActionRecord } from "../utils/promptUtils";
 
 // No types exported from notistack;
 type SnackbarKey = string | number;
 
 export const snackbarActions =
-  (closeSnackbar: (key?: SnackbarKey) => void) => (key: string) =>
-    (
-      <>
-        <IconButton
-          size="small"
-          aria-label="close"
-          color="inherit"
-          onClick={() => closeSnackbar(key)}
-        >
-          <CloseIcon fontSize="small" />
-        </IconButton>
-      </>
-    );
+  (closeSnackbar: (key?: SnackbarKey) => void) => (key: string) => (
+    <>
+      <IconButton
+        size="small"
+        aria-label="close"
+        color="inherit"
+        onClick={() => closeSnackbar(key)}
+      >
+        <CloseIcon fontSize="small" />
+      </IconButton>
+    </>
+  );
 
 export function dispatchSnackbar(
   enqueueSnackbar: (
     message: string,
-    options: { action: (key: string) => React.ReactNode; onClick: () => void }
+    options: { action: (key: string) => React.ReactNode; onClick: () => void },
   ) => SnackbarKey,
   closeSnackbar: (key?: string | number) => void,
-  gameState: GameState
+  gameState: GameState,
 ) {
-  const message = latestActionText(gameState);
-  if (!message) {
-    return;
-  }
-
   enqueueSnackbar(
-    message,
+    humanizeActionRecord(gameState, gameState.action_records.slice(-1)[0]),
     {
       action: snackbarActions(closeSnackbar),
       onClick: () => {
         closeSnackbar();
       },
-    }
+    },
   );
 }

--- a/ui/src/components/Snackbar.tsx
+++ b/ui/src/components/Snackbar.tsx
@@ -1,7 +1,7 @@
 import { IconButton } from "@mui/material";
 import CloseIcon from "@mui/icons-material/Close";
 import type { GameState } from "../utils/api.types";
-import { humanizeActionRecord } from "../utils/promptUtils";
+import { latestActionText } from "../utils/promptUtils";
 
 // No types exported from notistack;
 type SnackbarKey = string | number;
@@ -29,8 +29,13 @@ export function dispatchSnackbar(
   closeSnackbar: (key?: string | number) => void,
   gameState: GameState
 ) {
+  const message = latestActionText(gameState);
+  if (!message) {
+    return;
+  }
+
   enqueueSnackbar(
-    humanizeActionRecord(gameState, gameState.action_records.slice(-1)[0]),
+    message,
     {
       action: snackbarActions(closeSnackbar),
       onClick: () => {

--- a/ui/src/hooks/useDiscardBatchSubmission.ts
+++ b/ui/src/hooks/useDiscardBatchSubmission.ts
@@ -1,0 +1,48 @@
+import { useCallback, useState } from "react";
+import type {
+  DiscardGameAction,
+  GameAction,
+  GameState,
+  ResourceCard,
+} from "../utils/api.types";
+import { postAction } from "../utils/apiClient";
+
+type SubmitDiscardBatchParams = {
+  discardActionType: DiscardGameAction[1];
+  gameId: string;
+  humanColor: GameAction[0];
+  resources: ResourceCard[];
+};
+
+export function useDiscardBatchSubmission() {
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const submitDiscardBatch = useCallback(
+    async ({
+      discardActionType,
+      gameId,
+      humanColor,
+      resources,
+    }: SubmitDiscardBatchParams): Promise<GameState> => {
+      setIsSubmitting(true);
+      try {
+        let nextGameState: GameState | null = null;
+        for (const resource of resources) {
+          const action: GameAction = [humanColor, discardActionType, resource];
+          nextGameState = await postAction(gameId, action);
+        }
+
+        if (nextGameState === null) {
+          throw new Error("Discard batch submitted with no resources selected.");
+        }
+
+        return nextGameState;
+      } finally {
+        setIsSubmitting(false);
+      }
+    },
+    [],
+  );
+
+  return { isSubmitting, submitDiscardBatch };
+}

--- a/ui/src/pages/ActionsToolbar.tsx
+++ b/ui/src/pages/ActionsToolbar.tsx
@@ -36,6 +36,14 @@ import "./ActionsToolbar.scss";
 import { useSnackbar } from "notistack";
 import { dispatchSnackbar } from "../components/Snackbar";
 
+const RESOURCE_ORDER: ResourceCard[] = [
+  "WOOD",
+  "BRICK",
+  "SHEEP",
+  "WHEAT",
+  "ORE",
+];
+
 function PlayButtons() {
   const { gameId } = useParams();
   if (!gameId) {
@@ -78,14 +86,28 @@ function PlayButtons() {
       .map((action) => action[1])
   );
   const humanColor = getHumanColor(gameState);
+  const discardActionType =
+    gameState.current_playable_actions.find(
+      (action) => action[1] === "DISCARD" || action[1] === "DISCARD_RESOURCE"
+    )?.[1] ?? "DISCARD_RESOURCE";
   const setIsPlayingMonopoly = useCallback(() => {
     dispatch({ type: ACTIONS.SET_IS_PLAYING_MONOPOLY });
   }, [dispatch]);
   const getValidDiscardOptions = useCallback(() => {
-    return gameState.current_playable_actions
-      .filter((action) => action[1] === "DISCARD")
+    const discardOptions = gameState.current_playable_actions
+      .filter(
+        (action) => action[1] === "DISCARD" || action[1] === "DISCARD_RESOURCE"
+      )
       .map((action) => action[2] as ResourceCard);
-  }, [gameState.current_playable_actions]);
+    if (discardOptions.length > 0) {
+      return discardOptions;
+    }
+
+    // Fallback to the current hand if the discard actions are missing from the payload.
+    return RESOURCE_ORDER.filter(
+      (resource) => gameState.player_state[`${key}_${resource}_IN_HAND`] > 0
+    );
+  }, [gameState.current_playable_actions, gameState.player_state, key]);
   const getValidYearOfPlentyOptions = useCallback(() => {
     return gameState.current_playable_actions
       .filter((action) => action[1] === "PLAY_YEAR_OF_PLENTY")
@@ -102,7 +124,11 @@ function PlayButtons() {
           selectedResources as ResourceCard,
         ];
       } else if (isDiscard) {
-        action = [humanColor, "DISCARD", selectedResources as ResourceCard];
+        action = [
+          humanColor,
+          discardActionType,
+          selectedResources as ResourceCard,
+        ];
       } else if (isPlayingYearOfPlenty) {
         action = [
           humanColor,
@@ -126,6 +152,7 @@ function PlayButtons() {
       isPlayingMonopoly,
       isPlayingYearOfPlenty,
       isDiscard,
+      discardActionType,
     ]
   );
   const handleOpenResourceSelector = useCallback(() => {

--- a/ui/src/pages/ActionsToolbar.tsx
+++ b/ui/src/pages/ActionsToolbar.tsx
@@ -81,6 +81,11 @@ function PlayButtons() {
   const setIsPlayingMonopoly = useCallback(() => {
     dispatch({ type: ACTIONS.SET_IS_PLAYING_MONOPOLY });
   }, [dispatch]);
+  const getValidDiscardOptions = useCallback(() => {
+    return gameState.current_playable_actions
+      .filter((action) => action[1] === "DISCARD")
+      .map((action) => action[2] as ResourceCard);
+  }, [gameState.current_playable_actions]);
   const getValidYearOfPlentyOptions = useCallback(() => {
     return gameState.current_playable_actions
       .filter((action) => action[1] === "PLAY_YEAR_OF_PLENTY")
@@ -96,6 +101,8 @@ function PlayButtons() {
           "PLAY_MONOPOLY",
           selectedResources as ResourceCard,
         ];
+      } else if (isDiscard) {
+        action = [humanColor, "DISCARD", selectedResources as ResourceCard];
       } else if (isPlayingYearOfPlenty) {
         action = [
           humanColor,
@@ -118,6 +125,7 @@ function PlayButtons() {
       closeSnackbar,
       isPlayingMonopoly,
       isPlayingYearOfPlenty,
+      isDiscard,
     ]
   );
   const handleOpenResourceSelector = useCallback(() => {
@@ -230,7 +238,6 @@ function PlayButtons() {
     dispatch({ type: ACTIONS.SET_IS_MOVING_ROBBER });
   }, [dispatch]);
   const rollAction = carryOutAction([humanColor, "ROLL", null]);
-  const proceedAction = carryOutAction();
   const endTurnAction = carryOutAction([humanColor, "END_TURN", null]);
   return (
     <>
@@ -265,7 +272,7 @@ function PlayButtons() {
         startIcon={<NavigateNextIcon />}
         onClick={
           isDiscard
-            ? proceedAction
+            ? handleOpenResourceSelector
             : isMoveRobber
             ? setIsMovingRobber
             : isPlayingYearOfPlenty || isPlayingMonopoly
@@ -292,9 +299,17 @@ function PlayButtons() {
           dispatch({ type: ACTIONS.CANCEL_MONOPOLY });
           dispatch({ type: ACTIONS.CANCEL_YEAR_OF_PLENTY });
         }}
-        options={getValidYearOfPlentyOptions()}
+        options={
+          isDiscard ? getValidDiscardOptions() : getValidYearOfPlentyOptions()
+        }
         onSelect={handleResourceSelection}
-        mode={isPlayingMonopoly ? "monopoly" : "yearOfPlenty"}
+        mode={
+          isDiscard
+            ? "discard"
+            : isPlayingMonopoly
+            ? "monopoly"
+            : "yearOfPlenty"
+        }
       />
     </>
   );

--- a/ui/src/pages/ActionsToolbar.tsx
+++ b/ui/src/pages/ActionsToolbar.tsx
@@ -25,12 +25,14 @@ import Hidden from "../components/Hidden";
 import Prompt from "../components/Prompt";
 import ResourceCards from "../components/ResourceCards";
 import ResourceSelector from "../components/ResourceSelector";
+import DiscardPlannerDialog from "../components/DiscardPlannerDialog";
 import { store } from "../store";
 import ACTIONS from "../actions";
 import type { GameAction, ResourceCard } from "../utils/api.types"; // Add GameState to the import, adjust path if needed
 import { getHumanColor, playerKey } from "../utils/stateUtils";
 import { postAction } from "../utils/apiClient";
 import { humanizeTradeAction } from "../utils/promptUtils";
+import { useDiscardBatchSubmission } from "../hooks/useDiscardBatchSubmission";
 
 import "./ActionsToolbar.scss";
 import { useSnackbar } from "notistack";
@@ -53,6 +55,8 @@ function PlayButtons() {
   const { state, dispatch } = useContext(store);
   const { enqueueSnackbar, closeSnackbar } = useSnackbar();
   const [resourceSelectorOpen, setResourceSelectorOpen] = useState(false);
+  const [discardPlannerOpen, setDiscardPlannerOpen] = useState(false);
+  const { isSubmitting, submitDiscardBatch } = useDiscardBatchSubmission();
 
   const carryOutAction = useCallback(
     memoize((action?: GameAction) => async () => {
@@ -93,19 +97,18 @@ function PlayButtons() {
   const setIsPlayingMonopoly = useCallback(() => {
     dispatch({ type: ACTIONS.SET_IS_PLAYING_MONOPOLY });
   }, [dispatch]);
-  const getValidDiscardOptions = useCallback(() => {
-    const discardOptions = gameState.current_playable_actions
-      .filter((action) => action[1] === "DISCARD_RESOURCE")
-      .map((action) => action[2] as ResourceCard);
-    if (discardOptions.length > 0) {
-      return discardOptions;
-    }
-
-    // Fallback to the current hand if the discard actions are missing from the payload.
-    return RESOURCE_ORDER.filter(
-      (resource) => gameState.player_state[`${key}_${resource}_IN_HAND`] > 0,
+  const getDiscardResourceCounts = useCallback(() => {
+    return RESOURCE_ORDER.reduce(
+      (counts, resource) => {
+        const inHand = gameState.player_state[`${key}_${resource}_IN_HAND`];
+        if (inHand > 0) {
+          counts[resource] = inHand;
+        }
+        return counts;
+      },
+      {} as Partial<Record<ResourceCard, number>>,
     );
-  }, [gameState.current_playable_actions, gameState.player_state, key]);
+  }, [gameState.player_state, key]);
   const getValidYearOfPlentyOptions = useCallback(() => {
     return gameState.current_playable_actions
       .filter((action) => action[1] === "PLAY_YEAR_OF_PLENTY")
@@ -114,6 +117,7 @@ function PlayButtons() {
   const handleResourceSelection = useCallback(
     async (selectedResources: ResourceCard | ResourceCard[]) => {
       setResourceSelectorOpen(false);
+      let nextGameState;
       let action: GameAction;
       if (isPlayingMonopoly) {
         action = [
@@ -121,25 +125,20 @@ function PlayButtons() {
           "PLAY_MONOPOLY",
           selectedResources as ResourceCard,
         ];
-      } else if (isDiscard) {
-        action = [
-          humanColor,
-          discardActionType,
-          selectedResources as ResourceCard,
-        ];
+        nextGameState = await postAction(gameId, action);
       } else if (isPlayingYearOfPlenty) {
         action = [
           humanColor,
           "PLAY_YEAR_OF_PLENTY",
           selectedResources as [ResourceCard] | [ResourceCard, ResourceCard],
         ];
+        nextGameState = await postAction(gameId, action);
       } else {
         console.error("Invalid resource selector mode");
         return;
       }
-      const gameState = await postAction(gameId, action);
-      dispatch({ type: ACTIONS.SET_GAME_STATE, data: gameState });
-      dispatchSnackbar(enqueueSnackbar, closeSnackbar, gameState);
+      dispatch({ type: ACTIONS.SET_GAME_STATE, data: nextGameState });
+      dispatchSnackbar(enqueueSnackbar, closeSnackbar, nextGameState);
     },
     [
       gameId,
@@ -149,13 +148,36 @@ function PlayButtons() {
       closeSnackbar,
       isPlayingMonopoly,
       isPlayingYearOfPlenty,
-      isDiscard,
-      discardActionType,
     ],
   );
   const handleOpenResourceSelector = useCallback(() => {
     setResourceSelectorOpen(true);
   }, []);
+  const handleOpenDiscardPlanner = useCallback(() => {
+    setDiscardPlannerOpen(true);
+  }, []);
+  const handleDiscardSelection = useCallback(
+    async (resources: ResourceCard[]) => {
+      setDiscardPlannerOpen(false);
+      const nextGameState = await submitDiscardBatch({
+        discardActionType,
+        gameId,
+        humanColor,
+        resources,
+      });
+      dispatch({ type: ACTIONS.SET_GAME_STATE, data: nextGameState });
+      dispatchSnackbar(enqueueSnackbar, closeSnackbar, nextGameState);
+    },
+    [
+      discardActionType,
+      gameId,
+      humanColor,
+      submitDiscardBatch,
+      dispatch,
+      enqueueSnackbar,
+      closeSnackbar,
+    ],
+  );
   const setIsPlayingYearOfPlenty = useCallback(() => {
     dispatch({ type: ACTIONS.SET_IS_PLAYING_YEAR_OF_PLENTY });
   }, [dispatch]);
@@ -291,13 +313,17 @@ function PlayButtons() {
         Trade
       </OptionsButton>
       <Button
-        disabled={gameState.is_initial_build_phase || isRoadBuilding}
+        disabled={
+          gameState.is_initial_build_phase ||
+          isRoadBuilding ||
+          isSubmitting
+        }
         variant="contained"
         color="primary"
         startIcon={<NavigateNextIcon />}
         onClick={
           isDiscard
-            ? handleOpenResourceSelector
+            ? handleOpenDiscardPlanner
             : isMoveRobber
               ? setIsMovingRobber
               : isPlayingYearOfPlenty || isPlayingMonopoly
@@ -324,17 +350,17 @@ function PlayButtons() {
           dispatch({ type: ACTIONS.CANCEL_MONOPOLY });
           dispatch({ type: ACTIONS.CANCEL_YEAR_OF_PLENTY });
         }}
-        options={
-          isDiscard ? getValidDiscardOptions() : getValidYearOfPlentyOptions()
-        }
+        options={getValidYearOfPlentyOptions()}
         onSelect={handleResourceSelection}
-        mode={
-          isDiscard
-            ? "discard"
-            : isPlayingMonopoly
-              ? "monopoly"
-              : "yearOfPlenty"
-        }
+        mode={isPlayingMonopoly ? "monopoly" : "yearOfPlenty"}
+      />
+      <DiscardPlannerDialog
+        open={discardPlannerOpen}
+        onClose={() => setDiscardPlannerOpen(false)}
+        onConfirm={handleDiscardSelection}
+        remainingDiscardCount={gameState.current_discard_count}
+        discardResourceCounts={getDiscardResourceCounts()}
+        submitting={isSubmitting}
       />
     </>
   );

--- a/ui/src/pages/ActionsToolbar.tsx
+++ b/ui/src/pages/ActionsToolbar.tsx
@@ -60,7 +60,7 @@ function PlayButtons() {
       dispatch({ type: ACTIONS.SET_GAME_STATE, data: gameState });
       dispatchSnackbar(enqueueSnackbar, closeSnackbar, gameState);
     }),
-    [enqueueSnackbar, closeSnackbar]
+    [enqueueSnackbar, closeSnackbar],
   );
 
   const {
@@ -83,21 +83,19 @@ function PlayButtons() {
   const playableDevCardTypes = new Set(
     gameState.current_playable_actions
       .filter((action) => action[1].startsWith("PLAY"))
-      .map((action) => action[1])
+      .map((action) => action[1]),
   );
   const humanColor = getHumanColor(gameState);
   const discardActionType =
     gameState.current_playable_actions.find(
-      (action) => action[1] === "DISCARD" || action[1] === "DISCARD_RESOURCE"
+      (action) => action[1] === "DISCARD_RESOURCE",
     )?.[1] ?? "DISCARD_RESOURCE";
   const setIsPlayingMonopoly = useCallback(() => {
     dispatch({ type: ACTIONS.SET_IS_PLAYING_MONOPOLY });
   }, [dispatch]);
   const getValidDiscardOptions = useCallback(() => {
     const discardOptions = gameState.current_playable_actions
-      .filter(
-        (action) => action[1] === "DISCARD" || action[1] === "DISCARD_RESOURCE"
-      )
+      .filter((action) => action[1] === "DISCARD_RESOURCE")
       .map((action) => action[2] as ResourceCard);
     if (discardOptions.length > 0) {
       return discardOptions;
@@ -105,7 +103,7 @@ function PlayButtons() {
 
     // Fallback to the current hand if the discard actions are missing from the payload.
     return RESOURCE_ORDER.filter(
-      (resource) => gameState.player_state[`${key}_${resource}_IN_HAND`] > 0
+      (resource) => gameState.player_state[`${key}_${resource}_IN_HAND`] > 0,
     );
   }, [gameState.current_playable_actions, gameState.player_state, key]);
   const getValidYearOfPlentyOptions = useCallback(() => {
@@ -153,7 +151,7 @@ function PlayButtons() {
       isPlayingYearOfPlenty,
       isDiscard,
       discardActionType,
-    ]
+    ],
   );
   const handleOpenResourceSelector = useCallback(() => {
     setResourceSelectorOpen(true);
@@ -203,9 +201,9 @@ function PlayButtons() {
       : gameState.current_playable_actions
           .filter(
             (action) =>
-              action[1].startsWith("BUY") || action[1].startsWith("BUILD")
+              action[1].startsWith("BUY") || action[1].startsWith("BUILD"),
           )
-          .map((a) => a[1])
+          .map((a) => a[1]),
   );
   const buyDevCard = useCallback(async () => {
     const action: GameAction = [humanColor, "BUY_DEVELOPMENT_CARD", null];
@@ -246,7 +244,7 @@ function PlayButtons() {
   ];
 
   const tradeActions = gameState.current_playable_actions.filter(
-    (action) => action[1] === "MARITIME_TRADE"
+    (action) => action[1] === "MARITIME_TRADE",
   );
   const tradeItems = React.useMemo(() => {
     const items = tradeActions.map((action) => {
@@ -301,23 +299,23 @@ function PlayButtons() {
           isDiscard
             ? handleOpenResourceSelector
             : isMoveRobber
-            ? setIsMovingRobber
-            : isPlayingYearOfPlenty || isPlayingMonopoly
-            ? handleOpenResourceSelector
-            : isRoll
-            ? rollAction
-            : endTurnAction
+              ? setIsMovingRobber
+              : isPlayingYearOfPlenty || isPlayingMonopoly
+                ? handleOpenResourceSelector
+                : isRoll
+                  ? rollAction
+                  : endTurnAction
         }
       >
         {isDiscard
           ? "DISCARD"
           : isMoveRobber
-          ? "ROB"
-          : isPlayingYearOfPlenty || isPlayingMonopoly
-          ? "SELECT"
-          : isRoll
-          ? "ROLL"
-          : "END"}
+            ? "ROB"
+            : isPlayingYearOfPlenty || isPlayingMonopoly
+              ? "SELECT"
+              : isRoll
+                ? "ROLL"
+                : "END"}
       </Button>
       <ResourceSelector
         open={resourceSelectorOpen}
@@ -334,8 +332,8 @@ function PlayButtons() {
           isDiscard
             ? "discard"
             : isPlayingMonopoly
-            ? "monopoly"
-            : "yearOfPlenty"
+              ? "monopoly"
+              : "yearOfPlenty"
         }
       />
     </>
@@ -518,7 +516,7 @@ function OptionsButton({
                       key={item.label}
                       onClick={
                         handleClose(
-                          item.onClick
+                          item.onClick,
                         ) as unknown as React.MouseEventHandler
                       }
                       disabled={item.disabled}

--- a/ui/src/pages/HomePage.tsx
+++ b/ui/src/pages/HomePage.tsx
@@ -54,7 +54,6 @@ export default function HomePage() {
           <>
             <ul>
               <li>OPEN HAND</li>
-              <li>NO CHOICE DURING DISCARD</li>
             </ul>
             <div className="player-count-selector">
               <div className="player-count-label">Number of Players</div>

--- a/ui/src/pages/ZoomableBoard.tsx
+++ b/ui/src/pages/ZoomableBoard.tsx
@@ -129,9 +129,11 @@ export default function ZoomableBoard({ replayMode }: ZoomableBoardProps) {
         // Find the "MOVE_ROBBER" action in current_playable_actions that
         // corresponds to the tile coordinate selected by the user
         const matchingAction = gameState.current_playable_actions.find(
-          ([, action_type, [action_coordinate, ,]]) =>
-            action_type === "MOVE_ROBBER" &&
-            action_coordinate.every((val: number, index: number) => val === coordinate[index])
+          (action) =>
+            action[1] === "MOVE_ROBBER" &&
+            action[2][0].every(
+              (val: number, index: number) => val === coordinate[index],
+            ),
         );
         if (matchingAction) {
           postAction(gameId, matchingAction).then((gameState) => {

--- a/ui/src/utils/api.types.ts
+++ b/ui/src/utils/api.types.ts
@@ -11,7 +11,7 @@ export type TileCoordinate = [number, number, number];
 export type GameActionRecord =
   // These are the special cases
   | [RollGameAction, [number, number]]
-  | [DiscardGameAction, ResourceCard[]]
+  | [DiscardGameAction, ResourceCard]
   | [MoveRobberAction, ResourceCard | null]
   | [BuyDevelopmentCardAction, DevelopmentCard]
   // These are deterministic and carry no extra info
@@ -25,12 +25,8 @@ export type GameActionRecord =
   | [MaritimeTradeAction, null]
   | [EndTurnAction, null];
 
-export type RollGameAction = [Color, "ROLL", [number, number] | null];
-export type DiscardGameAction = [
-  Color,
-  "DISCARD" | "DISCARD_RESOURCE",
-  ResourceCard | null
-];
+export type RollGameAction = [Color, "ROLL", null];
+export type DiscardGameAction = [Color, "DISCARD_RESOURCE", ResourceCard];
 export type BuyDevelopmentCardAction = [Color, "BUY_DEVELOPMENT_CARD", null];
 export type BuildSettlementAction = [Color, "BUILD_SETTLEMENT", number];
 export type BuildCityAction = [Color, "BUILD_CITY", number];
@@ -41,17 +37,17 @@ export type PlayMonopolyAction = [Color, "PLAY_MONOPOLY", ResourceCard];
 export type PlayYearOfPlentyAction = [
   Color,
   "PLAY_YEAR_OF_PLENTY",
-  [ResourceCard] | [ResourceCard, ResourceCard]
+  [ResourceCard] | [ResourceCard, ResourceCard],
 ];
 export type MoveRobberAction = [
   Color,
   "MOVE_ROBBER",
-  [TileCoordinate, string?, string?]
+  [TileCoordinate, string?],
 ];
 export type MaritimeTradeAction = [
   Color,
   "MARITIME_TRADE",
-  (ResourceCard | null)[]
+  (ResourceCard | null)[],
 ];
 export type EndTurnAction = [Color, "END_TURN", null];
 
@@ -110,8 +106,7 @@ export type GameState = {
   winning_color?: Color;
   current_prompt: string;
   player_state: Record<string, PlayerState>;
-  action_records?: GameActionRecord[];
-  actions?: GameAction[];
+  action_records: GameActionRecord[];
   robber_coordinate: TileCoordinate;
   nodes: Array<{
     id: number;

--- a/ui/src/utils/api.types.ts
+++ b/ui/src/utils/api.types.ts
@@ -26,7 +26,11 @@ export type GameActionRecord =
   | [EndTurnAction, null];
 
 export type RollGameAction = [Color, "ROLL", [number, number] | null];
-export type DiscardGameAction = [Color, "DISCARD", ResourceCard | null];
+export type DiscardGameAction = [
+  Color,
+  "DISCARD" | "DISCARD_RESOURCE",
+  ResourceCard | null
+];
 export type BuyDevelopmentCardAction = [Color, "BUY_DEVELOPMENT_CARD", null];
 export type BuildSettlementAction = [Color, "BUILD_SETTLEMENT", number];
 export type BuildCityAction = [Color, "BUILD_CITY", number];

--- a/ui/src/utils/api.types.ts
+++ b/ui/src/utils/api.types.ts
@@ -108,6 +108,7 @@ export type GameState = {
   player_state: Record<string, PlayerState>;
   action_records: GameActionRecord[];
   robber_coordinate: TileCoordinate;
+  current_discard_count: number;
   nodes: Array<{
     id: number;
     tile_coordinate: TileCoordinate;

--- a/ui/src/utils/api.types.ts
+++ b/ui/src/utils/api.types.ts
@@ -25,8 +25,8 @@ export type GameActionRecord =
   | [MaritimeTradeAction, null]
   | [EndTurnAction, null];
 
-export type RollGameAction = [Color, "ROLL", null];
-export type DiscardGameAction = [Color, "DISCARD", null];
+export type RollGameAction = [Color, "ROLL", [number, number] | null];
+export type DiscardGameAction = [Color, "DISCARD", ResourceCard | null];
 export type BuyDevelopmentCardAction = [Color, "BUY_DEVELOPMENT_CARD", null];
 export type BuildSettlementAction = [Color, "BUILD_SETTLEMENT", number];
 export type BuildCityAction = [Color, "BUILD_CITY", number];
@@ -42,7 +42,7 @@ export type PlayYearOfPlentyAction = [
 export type MoveRobberAction = [
   Color,
   "MOVE_ROBBER",
-  [TileCoordinate, string?]
+  [TileCoordinate, string?, string?]
 ];
 export type MaritimeTradeAction = [
   Color,
@@ -106,7 +106,8 @@ export type GameState = {
   winning_color?: Color;
   current_prompt: string;
   player_state: Record<string, PlayerState>;
-  action_records: GameActionRecord[];
+  action_records?: GameActionRecord[];
+  actions?: GameAction[];
   robber_coordinate: TileCoordinate;
   nodes: Array<{
     id: number;

--- a/ui/src/utils/promptUtils.test.ts
+++ b/ui/src/utils/promptUtils.test.ts
@@ -180,10 +180,10 @@ describe("humanizeAction", () => {
   test("DISCARD action", () => {
     expect(
       humanizeActionRecord(baseGameState, [
-        ["ORANGE", "DISCARD", null],
+        ["ORANGE", "DISCARD", "WHEAT"],
         ["WHEAT"],
       ])
-    ).toBe("YOU DISCARDED");
+    ).toBe("YOU DISCARDED WHEAT");
   });
 
   test("BUY_DEVELOPMENT_CARD action", () => {

--- a/ui/src/utils/promptUtils.test.ts
+++ b/ui/src/utils/promptUtils.test.ts
@@ -177,10 +177,10 @@ describe("humanizeAction", () => {
     ).toBe("BOT ROLLED A 7");
   });
 
-  test("DISCARD action", () => {
+  test("DISCARD_RESOURCE action", () => {
     expect(
       humanizeActionRecord(baseGameState, [
-        ["ORANGE", "DISCARD", "WHEAT"],
+        ["ORANGE", "DISCARD_RESOURCE", "WHEAT"],
         ["WHEAT"],
       ])
     ).toBe("YOU DISCARDED WHEAT");

--- a/ui/src/utils/promptUtils.test.ts
+++ b/ui/src/utils/promptUtils.test.ts
@@ -181,7 +181,7 @@ describe("humanizeAction", () => {
     expect(
       humanizeActionRecord(baseGameState, [
         ["ORANGE", "DISCARD_RESOURCE", "WHEAT"],
-        ["WHEAT"],
+        "WHEAT",
       ])
     ).toBe("YOU DISCARDED WHEAT");
   });

--- a/ui/src/utils/promptUtils.ts
+++ b/ui/src/utils/promptUtils.ts
@@ -1,5 +1,4 @@
 import type {
-  GameAction,
   Tile,
   PlacedTile,
   GameActionRecord,
@@ -11,71 +10,6 @@ import type {
   ResourceCard,
 } from "./api.types";
 import type { GameState } from "./api.types";
-
-export function humanizeAction(gameState: GameState, action: GameAction) {
-  const botColors = gameState.bot_colors;
-  const player = botColors.includes(action[0]) ? "BOT" : "YOU";
-  switch (action[1]) {
-    case "ROLL":
-      if (!action[2]) {
-        throw new Error("did not get Rolling outcomes back from Server! output");
-      }
-      return `${player} ROLLED A ${action[2][0] + action[2][1]}`;
-    case "DISCARD":
-    case "DISCARD_RESOURCE":
-      return action[2] ? `${player} DISCARDED ${action[2]}` : `${player} DISCARDED`;
-    case "BUY_DEVELOPMENT_CARD":
-      return `${player} BOUGHT DEVELOPMENT CARD`;
-    case "BUILD_SETTLEMENT":
-    case "BUILD_CITY": {
-      const parts = action[1].split("_");
-      const building = parts[parts.length - 1];
-      const tileId = action[2];
-      const tiles = gameState.adjacent_tiles[tileId];
-      const tileString = tiles.map(getShortTileString).join("-");
-      return `${player} BUILT ${building} ON ${tileString}`;
-    }
-    case "BUILD_ROAD": {
-      const edge = action[2];
-      const a = gameState.adjacent_tiles[edge[0]].map((t) => t.id);
-      const b = gameState.adjacent_tiles[edge[1]].map((t) => t.id);
-      const intersection = a.filter((t) => b.includes(t));
-      const tiles = intersection.map(
-        (tileId) => findTileById(gameState, tileId).tile
-      );
-      const edgeString = tiles.map(getShortTileString).join("-");
-      return `${player} BUILT ROAD ON ${edgeString}`;
-    }
-    case "PLAY_KNIGHT_CARD":
-      return `${player} PLAYED KNIGHT CARD`;
-    case "PLAY_ROAD_BUILDING":
-      return `${player} PLAYED ROAD BUILDING`;
-    case "PLAY_MONOPOLY":
-      return `${player} MONOPOLIZED ${action[2]}`;
-    case "PLAY_YEAR_OF_PLENTY": {
-      const firstResource = action[2][0];
-      const secondResource = action[2][1];
-      if (secondResource) {
-        return `${player} PLAYED YEAR OF PLENTY. CLAIMED ${firstResource} AND ${secondResource}`;
-      }
-      return `${player} PLAYED YEAR OF PLENTY. CLAIMED ${firstResource}`;
-    }
-    case "MOVE_ROBBER": {
-      const tile = findTileByCoordinate(gameState, action[2][0]);
-      const tileString = getTileString(tile);
-      const stolenResource = action[2][2] ? ` (STOLE ${action[2][2]})` : "";
-      return `${player} ROBBED ${tileString}${stolenResource}`;
-    }
-    case "MARITIME_TRADE": {
-      const label = humanizeTradeAction(action as MaritimeTradeAction);
-      return `${player} TRADED ${label}`;
-    }
-    case "END_TURN":
-      return `${player} ENDED TURN`;
-    default:
-      throw new Error(`Unknown action type: ${action[1]}`);
-  }
-}
 
 export function humanizeActionRecord(
   gameState: GameState,
@@ -166,11 +100,6 @@ export function latestActionText(gameState: GameState) {
   const latestActionRecord = gameState.action_records?.slice(-1)[0];
   if (latestActionRecord) {
     return humanizeActionRecord(gameState, latestActionRecord);
-  }
-
-  const latestAction = gameState.actions?.slice(-1)[0];
-  if (latestAction) {
-    return humanizeAction(gameState, latestAction);
   }
 
   return "";

--- a/ui/src/utils/promptUtils.ts
+++ b/ui/src/utils/promptUtils.ts
@@ -22,6 +22,7 @@ export function humanizeAction(gameState: GameState, action: GameAction) {
       }
       return `${player} ROLLED A ${action[2][0] + action[2][1]}`;
     case "DISCARD":
+    case "DISCARD_RESOURCE":
       return action[2] ? `${player} DISCARDED ${action[2]}` : `${player} DISCARDED`;
     case "BUY_DEVELOPMENT_CARD":
       return `${player} BOUGHT DEVELOPMENT CARD`;
@@ -89,6 +90,7 @@ export function humanizeActionRecord(
       return `${player} ROLLED A ${action[0] + action[1]}`;
     }
     case "DISCARD":
+    case "DISCARD_RESOURCE":
       return `${player} DISCARDED ${
         (actionRecord[1] as ResourceCard[])[0]
       }`;

--- a/ui/src/utils/promptUtils.ts
+++ b/ui/src/utils/promptUtils.ts
@@ -13,7 +13,7 @@ import type { GameState } from "./api.types";
 
 export function humanizeActionRecord(
   gameState: GameState,
-  actionRecord: GameActionRecord
+  actionRecord: GameActionRecord,
 ) {
   const botColors = gameState.bot_colors;
   const action = actionRecord[0];
@@ -23,11 +23,8 @@ export function humanizeActionRecord(
       const action = actionRecord[1] as [number, number];
       return `${player} ROLLED A ${action[0] + action[1]}`;
     }
-    case "DISCARD":
     case "DISCARD_RESOURCE":
-      return `${player} DISCARDED ${
-        (actionRecord[1] as ResourceCard[])[0]
-      }`;
+      return `${player} DISCARDED ${actionRecord[1] as ResourceCard}`;
     case "BUY_DEVELOPMENT_CARD":
       return `${player} BOUGHT DEVELOPMENT CARD`;
     case "BUILD_SETTLEMENT":
@@ -47,7 +44,7 @@ export function humanizeActionRecord(
       const b = gameState.adjacent_tiles[edge[1]].map((t) => t.id);
       const intersection = a.filter((t) => b.includes(t));
       const tiles = intersection.map(
-        (tileId) => findTileById(gameState, tileId).tile
+        (tileId) => findTileById(gameState, tileId).tile,
       );
       const edgeString = tiles.map(getShortTileString).join("-");
       return `${player} BUILT ROAD ON ${edgeString}`;
@@ -96,15 +93,6 @@ export function humanizeTradeAction(action: MaritimeTradeAction): string {
   return `${out.length} ${out[0]} => ${action[2][4]}`;
 }
 
-export function latestActionText(gameState: GameState) {
-  const latestActionRecord = gameState.action_records?.slice(-1)[0];
-  if (latestActionRecord) {
-    return humanizeActionRecord(gameState, latestActionRecord);
-  }
-
-  return "";
-}
-
 export function findTileByCoordinate(gameState: GameState, coordinate: any) {
   for (const tile of Object.values(gameState.tiles)) {
     if (JSON.stringify(tile.coordinate) === JSON.stringify(coordinate)) {
@@ -112,7 +100,7 @@ export function findTileByCoordinate(gameState: GameState, coordinate: any) {
     }
   }
   throw new Error(
-    `Tile not found for coordinate: ${JSON.stringify(coordinate)}`
+    `Tile not found for coordinate: ${JSON.stringify(coordinate)}`,
   );
 }
 

--- a/ui/src/utils/promptUtils.ts
+++ b/ui/src/utils/promptUtils.ts
@@ -1,4 +1,5 @@
 import type {
+  GameAction,
   Tile,
   PlacedTile,
   GameActionRecord,
@@ -7,8 +8,73 @@ import type {
   BuildRoadAction,
   PlayYearOfPlentyAction,
   MoveRobberAction,
+  ResourceCard,
 } from "./api.types";
 import type { GameState } from "./api.types";
+
+export function humanizeAction(gameState: GameState, action: GameAction) {
+  const botColors = gameState.bot_colors;
+  const player = botColors.includes(action[0]) ? "BOT" : "YOU";
+  switch (action[1]) {
+    case "ROLL":
+      if (!action[2]) {
+        throw new Error("did not get Rolling outcomes back from Server! output");
+      }
+      return `${player} ROLLED A ${action[2][0] + action[2][1]}`;
+    case "DISCARD":
+      return action[2] ? `${player} DISCARDED ${action[2]}` : `${player} DISCARDED`;
+    case "BUY_DEVELOPMENT_CARD":
+      return `${player} BOUGHT DEVELOPMENT CARD`;
+    case "BUILD_SETTLEMENT":
+    case "BUILD_CITY": {
+      const parts = action[1].split("_");
+      const building = parts[parts.length - 1];
+      const tileId = action[2];
+      const tiles = gameState.adjacent_tiles[tileId];
+      const tileString = tiles.map(getShortTileString).join("-");
+      return `${player} BUILT ${building} ON ${tileString}`;
+    }
+    case "BUILD_ROAD": {
+      const edge = action[2];
+      const a = gameState.adjacent_tiles[edge[0]].map((t) => t.id);
+      const b = gameState.adjacent_tiles[edge[1]].map((t) => t.id);
+      const intersection = a.filter((t) => b.includes(t));
+      const tiles = intersection.map(
+        (tileId) => findTileById(gameState, tileId).tile
+      );
+      const edgeString = tiles.map(getShortTileString).join("-");
+      return `${player} BUILT ROAD ON ${edgeString}`;
+    }
+    case "PLAY_KNIGHT_CARD":
+      return `${player} PLAYED KNIGHT CARD`;
+    case "PLAY_ROAD_BUILDING":
+      return `${player} PLAYED ROAD BUILDING`;
+    case "PLAY_MONOPOLY":
+      return `${player} MONOPOLIZED ${action[2]}`;
+    case "PLAY_YEAR_OF_PLENTY": {
+      const firstResource = action[2][0];
+      const secondResource = action[2][1];
+      if (secondResource) {
+        return `${player} PLAYED YEAR OF PLENTY. CLAIMED ${firstResource} AND ${secondResource}`;
+      }
+      return `${player} PLAYED YEAR OF PLENTY. CLAIMED ${firstResource}`;
+    }
+    case "MOVE_ROBBER": {
+      const tile = findTileByCoordinate(gameState, action[2][0]);
+      const tileString = getTileString(tile);
+      const stolenResource = action[2][2] ? ` (STOLE ${action[2][2]})` : "";
+      return `${player} ROBBED ${tileString}${stolenResource}`;
+    }
+    case "MARITIME_TRADE": {
+      const label = humanizeTradeAction(action as MaritimeTradeAction);
+      return `${player} TRADED ${label}`;
+    }
+    case "END_TURN":
+      return `${player} ENDED TURN`;
+    default:
+      throw new Error(`Unknown action type: ${action[1]}`);
+  }
+}
 
 export function humanizeActionRecord(
   gameState: GameState,
@@ -23,7 +89,9 @@ export function humanizeActionRecord(
       return `${player} ROLLED A ${action[0] + action[1]}`;
     }
     case "DISCARD":
-      return `${player} DISCARDED`;
+      return `${player} DISCARDED ${
+        (actionRecord[1] as ResourceCard[])[0]
+      }`;
     case "BUY_DEVELOPMENT_CARD":
       return `${player} BOUGHT DEVELOPMENT CARD`;
     case "BUILD_SETTLEMENT":
@@ -90,6 +158,20 @@ export function humanizeTradeAction(action: MaritimeTradeAction): string {
     .slice(0, 4)
     .filter((resource: unknown) => resource !== null);
   return `${out.length} ${out[0]} => ${action[2][4]}`;
+}
+
+export function latestActionText(gameState: GameState) {
+  const latestActionRecord = gameState.action_records?.slice(-1)[0];
+  if (latestActionRecord) {
+    return humanizeActionRecord(gameState, latestActionRecord);
+  }
+
+  const latestAction = gameState.actions?.slice(-1)[0];
+  if (latestAction) {
+    return humanizeAction(gameState, latestAction);
+  }
+
+  return "";
 }
 
 export function findTileByCoordinate(gameState: GameState, coordinate: any) {


### PR DESCRIPTION
This PR builds on https://github.com/bcollazo/catanatron/pull/362. It changes the internal representation of `DISCARD_RESOURCE` actions to just a single resource. This simplifies handling as arrays. It also changes the Frontend to ask for all discards in one-go, and then presents them to the backend one at a time. Among other smaller non-funcional changes.