### PR TITLE
fix: block road extension through opponent's settlement endpoint

### DIFF
--- a/catanatron/catanatron/models/board.py
+++ b/catanatron/catanatron/models/board.py
@@ -143,6 +143,11 @@ class Board:
                     self.road_color, self.road_length = max(
                         self.road_lengths.items(), key=lambda e: e[1]
                     )
+                elif len(edges) == 1:
+                    # Endpoint blocked: remove node_id from opponent's component
+                    b_index = self._get_connected_component_index(node_id, edge_color)
+                    if b_index is not None:
+                        self.connected_components[edge_color][b_index].discard(node_id)
 
         self.board_buildable_ids.discard(node_id)
         for n in STATIC_GRAPH.neighbors(node_id):

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -630,3 +630,27 @@ def test_trading_sequence(fake_roll_dice):
     expected[index_of_a_resource_owned] -= 1
     expected[missing_resource_index] += 1
     assert get_player_freqdeck(game.state, p0.color) == expected
+
+def test_cannot_extend_road_past_enemy_settlement_at_endpoint():
+    # Blue has a road whose far endpoint is node 10.
+    # Red then builds a settlement at node 10 (normal phase).
+    # Blue should no longer be able to build roads from node 10.
+    players = [SimplePlayer(Color.RED), SimplePlayer(Color.BLUE)]
+    game = Game(players)
+    board = game.state.board
+
+    board.build_settlement(Color.BLUE, 12, initial_build_phase=True)
+    board.build_road(Color.BLUE, (12, 11))
+    board.build_road(Color.BLUE, (11, 10))
+
+    # Red reaches node 10 via their own road network and settles there.
+    board.build_settlement(Color.RED, 8, initial_build_phase=True)
+    board.build_road(Color.RED, (8, 9))
+    board.build_road(Color.RED, (9, 10))
+    board.build_settlement(Color.RED, 10, initial_build_phase=False)
+
+    blue_edges = board.buildable_edges(Color.BLUE)
+    assert all(10 not in edge for edge in blue_edges), (
+        f"Blue should not be able to build a road from enemy-settled node 10, "
+        f"but found: {[e for e in blue_edges if 10 in e]}"
+    )


### PR DESCRIPTION
When a settlement is built on a node that is the endpoint of an opponent's road (len == 1), the node was not removed from the opponent's connected components. This allowed the opponent to later build a road from that blocked endpoint, bypassing the "cannot build through a settlement" rule.

The len == 2 case (settlement in the middle of a road) was already handled correctly.

See issue #376 for additional details.