### PR TITLE
perf: remove duplicate production_features call in base_fn

### DIFF
--- a/catanatron/catanatron/players/value.py
+++ b/catanatron/catanatron/players/value.py
@@ -57,10 +57,9 @@ CONTENDER_WEIGHTS = {
 def base_fn(params=DEFAULT_WEIGHTS):
     def fn(game, p0_color):
         production_features = build_production_features(True)
-        our_production_sample = production_features(game, p0_color)
-        enemy_production_sample = production_features(game, p0_color)
-        production = value_production(our_production_sample, "P0")
-        enemy_production = value_production(enemy_production_sample, "P1", False)
+        production_sample = production_features(game, p0_color)
+        production = value_production(production_sample, "P0")
+        enemy_production = value_production(production_sample, "P1", False)
 
         key = player_key(game.state, p0_color)
         longest_road_length = get_longest_road_length(game.state, p0_color)


### PR DESCRIPTION
`base_fn` computes `production_features(game, p0_color)` twice with identical arguments, then reads `P0_*` keys from one result and `P1_*` keys from the other:

```python
our_production_sample = production_features(game, p0_color)
enemy_production_sample = production_features(game, p0_color)
```

`production_features` returns every player's production in a single pass (all `P0_*`, `P1_*`, ... keys are in the first dict), so the second call recomputes the identical dict. That happens at every evaluation — including every leaf of `AlphaBetaPlayer`'s depth-2 search. This PR removes the second call and reuses the sample.

**Behavior-neutral, verified:** we played seeded games before and after the change with `PYTHONHASHSEED` pinned, and compared winner, turn count, and a SHA-256 over the full action record for each seed — identical on every seed, for both `ValueFunctionPlayer` and `AlphaBetaPlayer` tables. The timing gain is modest in our measurements (~6% on AlphaBetaPlayer games; `Game.copy()` dominates runtime), but it is free.

Found while building a player on top of catanatron — thanks for the framework.

🤖 Generated with [Claude Code](https://claude.com/claude-code)