### PR TITLE
feat: add fair imperfect-information play

### DIFF
--- a/catanatron/catanatron/models/inventory.py
+++ b/catanatron/catanatron/models/inventory.py
@@ -1,0 +1,28 @@
+"""
+Typed, pure-data snapshot of the observing player's own private hand.
+
+Unlike ``public_state`` — which is restricted to facts every player can know —
+this is the observer's full inventory: exact resource counts and the identity
+of every development card held. It is built for the observer's color only and
+carried on ``Observation.inventory``; it is never computed for opponents, whose
+hands stay visible only as public counts.
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Inventory:
+    """The observer's private hand, keyed by card name (lowercase)."""
+
+    wood: int = 0
+    brick: int = 0
+    sheep: int = 0
+    wheat: int = 0
+    ore: int = 0
+    knight: int = 0
+    year_of_plenty: int = 0
+    monopoly: int = 0
+    road_building: int = 0
+    victory_point: int = 0
+    has_played_development_card: bool = False

--- a/catanatron/catanatron/models/inventory.py
+++ b/catanatron/catanatron/models/inventory.py
@@ -25,4 +25,6 @@ class Inventory:
     monopoly: int = 0
     road_building: int = 0
     victory_point: int = 0
+    actual_vps: int = 0
+    """Own hidden VP total, including face-down victory-point cards."""
     has_played_development_card: bool = False

--- a/catanatron/catanatron/models/observation.py
+++ b/catanatron/catanatron/models/observation.py
@@ -1,0 +1,84 @@
+"""
+A lazy, read-only, presentation-free view of the game for exactly one color.
+
+The Observation is a bot's entire information world. It never exposes the
+underlying Game or State, so a bot that only perceives Observations cannot
+read information no human could observe.
+"""
+
+from functools import cached_property
+
+from catanatron.features import create_sample
+from catanatron.models.enums import Action, ActionRecord, ActionType
+
+
+def _sanitize_record(record, observer_color):
+    """Returns a copy of the record with hidden identities redacted.
+
+    Full detail is retained for the observer's own records. For opponent
+    records: development-card purchases are redacted (both channels), and
+    stolen-card identities are redacted unless the observer was the victim.
+    Discards are public per tournament convention.
+    """
+    action = record.action
+    if action.color == observer_color:
+        return record
+
+    action_type = action.action_type
+    if action_type == ActionType.BUY_DEVELOPMENT_CARD:
+        return ActionRecord(Action(action.color, action_type, None), None)
+    elif action_type == ActionType.MOVE_ROBBER:
+        robbed_color = action.value[1] if action.value is not None else None
+        if robbed_color == observer_color:
+            return record
+        return ActionRecord(action, None)
+    return record
+
+
+class Observation:
+    """Lazy, read-only view of the game for exactly one color.
+
+    Args:
+        game (Game): full-truth engine state. Kept private.
+        color (Color): the color whose perspective this view represents.
+    """
+
+    def __init__(self, game, color):
+        self._game = game
+        self.color = color
+
+    @cached_property
+    def features(self):
+        """Imperfect-information snapshot, keyed relative to this color (P0).
+
+        Lazy; computed once per Observation. Reuses the RL extractors, so
+        fair bots share the exact representation agents train on.
+        """
+        return create_sample(self._game, self.color)
+
+    @property
+    def public_history(self):
+        """Sanitized action log (list of ActionRecord).
+
+        Hidden identities carried by opponent records are redacted according
+        to the table in the ADR. Runs on access and is O(history length).
+        """
+        return [
+            _sanitize_record(record, self.color)
+            for record in self._game.state.action_records
+        ]
+
+    @property
+    def current_prompt(self):
+        """The ActionPrompt the current player must respond to."""
+        return self._game.state.current_prompt
+
+    @property
+    def current_trade(self):
+        """The current trade offer (10-tuple plus trader index), if any."""
+        return self._game.state.current_trade
+
+    @property
+    def acceptees(self):
+        """Tuple of booleans, one per color, marking current trade acceptees."""
+        return self._game.state.acceptees

--- a/catanatron/catanatron/models/observation.py
+++ b/catanatron/catanatron/models/observation.py
@@ -7,6 +7,9 @@ engine mode (projected from a full-truth game) and deployed/site mode
 (built from external events).
 """
 
+from catanatron.models.inventory import Inventory
+from catanatron.models.public_state import PublicState
+
 
 class Observation:
     """Read-only, presentation-free snapshot of what one color perceives.
@@ -20,9 +23,11 @@ class Observation:
             respond to.
         current_trade (Tuple): the current trade offer, if any.
         acceptees (Tuple[bool]): current trade acceptees, one per color.
-        public_state (Dict[str, Any]): structured, pure-data snapshot of all
-            public state, keyed absolutely (by node/edge id and Color). Built
-            by the engine adapter; never holds a Game or State reference.
+        public_state (Optional[PublicState]): structured, pure-data snapshot
+            of all public state, keyed absolutely (by node/edge id and Color).
+            Built by the engine adapter; never holds a Game or State reference.
+        inventory (Optional[Inventory]): the observer's own private hand —
+            exact resources and dev cards. Computed for this color only.
     """
 
     def __init__(
@@ -33,7 +38,8 @@ class Observation:
         current_prompt,
         current_trade,
         acceptees,
-        public_state=None,
+        public_state: PublicState = None,
+        inventory: Inventory = None,
     ):
         self.color = color
         self.features = features
@@ -41,4 +47,5 @@ class Observation:
         self.current_prompt = current_prompt
         self.current_trade = current_trade
         self.acceptees = acceptees
-        self.public_state = public_state or {}
+        self.public_state = public_state
+        self.inventory = inventory

--- a/catanatron/catanatron/models/observation.py
+++ b/catanatron/catanatron/models/observation.py
@@ -1,84 +1,39 @@
 """
-A lazy, read-only, presentation-free view of the game for exactly one color.
+A read-only, presentation-free snapshot of what exactly one color perceives.
 
-The Observation is a bot's entire information world. It never exposes the
-underlying Game or State, so a bot that only perceives Observations cannot
-read information no human could observe.
+The Observation is an agent's entire information world. It is pure data:
+it carries no reference to a Game or State, so it is equally at home in
+engine mode (projected from a full-truth game) and deployed/site mode
+(built from external events).
 """
-
-from functools import cached_property
-
-from catanatron.features import create_sample
-from catanatron.models.enums import Action, ActionRecord, ActionType
-
-
-def _sanitize_record(record, observer_color):
-    """Returns a copy of the record with hidden identities redacted.
-
-    Full detail is retained for the observer's own records. For opponent
-    records: development-card purchases are redacted (both channels), and
-    stolen-card identities are redacted unless the observer was the victim.
-    Discards are public per tournament convention.
-    """
-    action = record.action
-    if action.color == observer_color:
-        return record
-
-    action_type = action.action_type
-    if action_type == ActionType.BUY_DEVELOPMENT_CARD:
-        return ActionRecord(Action(action.color, action_type, None), None)
-    elif action_type == ActionType.MOVE_ROBBER:
-        robbed_color = action.value[1] if action.value is not None else None
-        if robbed_color == observer_color:
-            return record
-        return ActionRecord(action, None)
-    return record
 
 
 class Observation:
-    """Lazy, read-only view of the game for exactly one color.
+    """Read-only, presentation-free snapshot of what one color perceives.
 
     Args:
-        game (Game): full-truth engine state. Kept private.
-        color (Color): the color whose perspective this view represents.
+        color (Color): the color whose perspective this snapshot represents.
+        features (Dict[str, Any]): imperfect-information feature snapshot,
+            keyed relative to this color (P0).
+        public_history (List[ActionRecord]): sanitized action log.
+        current_prompt (ActionPrompt): the prompt the current player must
+            respond to.
+        current_trade (Tuple): the current trade offer, if any.
+        acceptees (Tuple[bool]): current trade acceptees, one per color.
     """
 
-    def __init__(self, game, color):
-        self._game = game
+    def __init__(
+        self,
+        color,
+        features,
+        public_history,
+        current_prompt,
+        current_trade,
+        acceptees,
+    ):
         self.color = color
-
-    @cached_property
-    def features(self):
-        """Imperfect-information snapshot, keyed relative to this color (P0).
-
-        Lazy; computed once per Observation. Reuses the RL extractors, so
-        fair bots share the exact representation agents train on.
-        """
-        return create_sample(self._game, self.color)
-
-    @property
-    def public_history(self):
-        """Sanitized action log (list of ActionRecord).
-
-        Hidden identities carried by opponent records are redacted according
-        to the table in the ADR. Runs on access and is O(history length).
-        """
-        return [
-            _sanitize_record(record, self.color)
-            for record in self._game.state.action_records
-        ]
-
-    @property
-    def current_prompt(self):
-        """The ActionPrompt the current player must respond to."""
-        return self._game.state.current_prompt
-
-    @property
-    def current_trade(self):
-        """The current trade offer (10-tuple plus trader index), if any."""
-        return self._game.state.current_trade
-
-    @property
-    def acceptees(self):
-        """Tuple of booleans, one per color, marking current trade acceptees."""
-        return self._game.state.acceptees
+        self.features = features
+        self.public_history = public_history
+        self.current_prompt = current_prompt
+        self.current_trade = current_trade
+        self.acceptees = acceptees

--- a/catanatron/catanatron/models/observation.py
+++ b/catanatron/catanatron/models/observation.py
@@ -20,6 +20,9 @@ class Observation:
             respond to.
         current_trade (Tuple): the current trade offer, if any.
         acceptees (Tuple[bool]): current trade acceptees, one per color.
+        public_state (Dict[str, Any]): structured, pure-data snapshot of all
+            public state, keyed absolutely (by node/edge id and Color). Built
+            by the engine adapter; never holds a Game or State reference.
     """
 
     def __init__(
@@ -30,6 +33,7 @@ class Observation:
         current_prompt,
         current_trade,
         acceptees,
+        public_state=None,
     ):
         self.color = color
         self.features = features
@@ -37,3 +41,4 @@ class Observation:
         self.current_prompt = current_prompt
         self.current_trade = current_trade
         self.acceptees = acceptees
+        self.public_state = public_state or {}

--- a/catanatron/catanatron/models/observation.py
+++ b/catanatron/catanatron/models/observation.py
@@ -7,45 +7,60 @@ engine mode (projected from a full-truth game) and deployed/site mode
 (built from external events).
 """
 
+from dataclasses import dataclass
+from typing import Any, Dict, Optional, Tuple
+
+from catanatron.models.enums import ActionPrompt, ActionRecord
 from catanatron.models.inventory import Inventory
-from catanatron.models.public_state import PublicState
+from catanatron.models.player import Color
+from catanatron.models.public_state import PublicPlayer, PublicState
+from catanatron.models.trade import PendingTrades, TradeOffer
 
 
+@dataclass(frozen=True)
 class Observation:
     """Read-only, presentation-free snapshot of what one color perceives.
 
+    The core information world is ``public_state`` + ``pending_trades`` +
+    ``inventory`` + ``current_prompt``. ``features`` is the flat, P0-relative RL
+    vector surface — optional today for training-loop compatibility and unused
+    by agents that reason structurally.
+
     Args:
         color (Color): the color whose perspective this snapshot represents.
-        features (Dict[str, Any]): imperfect-information feature snapshot,
-            keyed relative to this color (P0).
-        public_history (List[ActionRecord]): sanitized action log.
-        current_prompt (ActionPrompt): the prompt the current player must
-            respond to.
-        current_trade (Tuple): the current trade offer, if any.
-        acceptees (Tuple[bool]): current trade acceptees, one per color.
+        features (Optional[Dict[str, Any]]): imperfect-information feature
+            snapshot, keyed relative to this color (P0). Optional; only needed
+            by RL consumers.
+        public_history (Tuple[ActionRecord, ...]): sanitized action log.
+        current_prompt (Optional[ActionPrompt]): the prompt the current player
+            must respond to.
+        pending_trades (PendingTrades): trades currently on the table awaiting
+            responses; empty when none. The engine allows one at a time today;
+            the container future-proofs site-mode rules with competing offers.
         public_state (Optional[PublicState]): structured, pure-data snapshot
             of all public state, keyed absolutely (by node/edge id and Color).
             Built by the engine adapter; never holds a Game or State reference.
         inventory (Optional[Inventory]): the observer's own private hand —
-            exact resources and dev cards. Computed for this color only.
+            exact resources and dev cards plus hidden actual victory points.
+            Computed for this color only.
+
+    Properties:
+        own (Optional[PublicPlayer]): this observer's own entry in
+            ``public_state.players``, for the idiomatic ``obs.own.public_vps``
+            style access.
     """
 
-    def __init__(
-        self,
-        color,
-        features,
-        public_history,
-        current_prompt,
-        current_trade,
-        acceptees,
-        public_state: PublicState = None,
-        inventory: Inventory = None,
-    ):
-        self.color = color
-        self.features = features
-        self.public_history = public_history
-        self.current_prompt = current_prompt
-        self.current_trade = current_trade
-        self.acceptees = acceptees
-        self.public_state = public_state
-        self.inventory = inventory
+    color: Color
+    features: Optional[Dict[str, Any]] = None
+    public_history: Tuple[ActionRecord, ...] = ()
+    current_prompt: Optional[ActionPrompt] = None
+    pending_trades: PendingTrades = PendingTrades()
+    public_state: Optional[PublicState] = None
+    inventory: Optional[Inventory] = None
+
+    @property
+    def own(self) -> Optional[PublicPlayer]:
+        """This observer's own public-player entry, or None without a public_state."""
+        if self.public_state is None:
+            return None
+        return self.public_state.players[self.color]

--- a/catanatron/catanatron/models/observation_agent.py
+++ b/catanatron/catanatron/models/observation_agent.py
@@ -1,0 +1,25 @@
+"""
+A fair bot that decides from Observations, never from a Game.
+
+An ObservationAgent is deployment-agnostic: the same class is driven by the
+local engine (through a PerspectivePlayer adapter) and by a future site-mode
+adapter that feeds observations built from external events.
+"""
+
+
+class ObservationAgent:
+    """Base class for agents that only ever perceive Observations.
+
+    Subclass and implement decide_observation. The fairness contract is
+    structural: an ObservationAgent never receives a Game.
+    """
+
+    def __init__(self, color):
+        self.color = color
+
+    def decide_observation(self, observation, playable_actions):
+        raise NotImplementedError
+
+    def reset_state(self):
+        """Hook for resetting memory between games."""
+        pass

--- a/catanatron/catanatron/models/perspective_player.py
+++ b/catanatron/catanatron/models/perspective_player.py
@@ -1,0 +1,18 @@
+from catanatron.models.observation import Observation
+from catanatron.models.player import Player
+
+
+class PerspectivePlayer(Player):
+    """Player that only ever perceives an Observation, never a Game.
+
+    Subclass and implement decide_observation. The fairness contract is
+    structural: a PerspectivePlayer never receives a Game.
+    """
+
+    def decide(self, game, playable_actions):
+        return self.decide_observation(
+            Observation(game, self.color), playable_actions
+        )
+
+    def decide_observation(self, observation, playable_actions):
+        raise NotImplementedError

--- a/catanatron/catanatron/models/perspective_player.py
+++ b/catanatron/catanatron/models/perspective_player.py
@@ -25,6 +25,7 @@ from catanatron.models.public_state import (
     PublicPlayer,
     PublicState,
 )
+from catanatron.models.tiles import LandTile
 from catanatron.models.trade import PendingTrades, TradeOffer
 from catanatron.state_functions import (
     player_key,
@@ -74,6 +75,11 @@ def _build_public_map(board):
     tiles = {}
     for tile in catan_map.tiles_by_id.values():
         tiles[tile.id] = (tile.resource, tile.number)
+    tile_coordinates = {
+        tile.id: coordinate
+        for coordinate, tile in catan_map.tiles.items()
+        if isinstance(tile, LandTile)
+    }
     ports = {}
     for port in catan_map.ports_by_id.values():
         (a_ref, b_ref) = PORT_DIRECTION_TO_NODEREFS[port.direction]
@@ -84,6 +90,7 @@ def _build_public_map(board):
     }
     return PublicMap(
         tiles=tiles,
+        tile_coordinates=tile_coordinates,
         ports=ports,
         adjacent_tiles=adjacent_tiles,
         land_nodes=frozenset(catan_map.land_nodes),
@@ -135,7 +142,7 @@ def _build_public_state(game):
         board=PublicBoard(
             buildings=dict(board.buildings),
             roads=roads,
-            robber_coordinate=board.robber_coordinate,
+            robber_tile_id=board.map.tiles[board.robber_coordinate].id,
             longest_road_color=board.road_color,
             longest_road_length=board.road_length,
             map=_build_public_map(board),

--- a/catanatron/catanatron/models/perspective_player.py
+++ b/catanatron/catanatron/models/perspective_player.py
@@ -1,18 +1,76 @@
+"""
+The engine-side adapter that feeds fair agents Observations.
+
+The game loop always hands Player.decide a perfect-information Game.
+PerspectivePlayer converts that Game into an Observation for the wrapped
+agent on every decision, so the agent never perceives more than a real
+player could observe.
+"""
+
+from catanatron.features import create_sample
+from catanatron.models.enums import Action, ActionRecord, ActionType
 from catanatron.models.observation import Observation
 from catanatron.models.player import Player
 
 
-class PerspectivePlayer(Player):
-    """Player that only ever perceives an Observation, never a Game.
+def _sanitize_record(record, observer_color):
+    """Returns a copy of the record with hidden identities redacted.
 
-    Subclass and implement decide_observation. The fairness contract is
-    structural: a PerspectivePlayer never receives a Game.
+    Full detail is retained for the observer's own records. For opponent
+    records: development-card purchases are redacted (both channels), and
+    stolen-card identities are redacted unless the observer was the victim.
+    Discards are public per tournament convention.
+    """
+    action = record.action
+    if action.color == observer_color:
+        return record
+
+    action_type = action.action_type
+    if action_type == ActionType.BUY_DEVELOPMENT_CARD:
+        return ActionRecord(Action(action.color, action_type, None), None)
+    elif action_type == ActionType.MOVE_ROBBER:
+        robbed_color = action.value[1] if action.value is not None else None
+        if robbed_color == observer_color:
+            return record
+        return ActionRecord(action, None)
+    return record
+
+
+def _sanitize_history(game, observer_color):
+    """Sanitizes the full-truth action log for the given observer color."""
+    return [
+        _sanitize_record(record, observer_color)
+        for record in game.state.action_records
+    ]
+
+
+class PerspectivePlayer(Player):
+    """Player that adapts an ObservationAgent into the perfect-info game loop.
+
+    On every decision the given game is projected down to the agent's color
+    as an Observation (features, sanitized history, and trade state) and the
+    agent's decide_observation is called. The agent never receives the Game.
+
+    Args:
+        agent (ObservationAgent): the fair agent to drive.
+        is_bot (bool): whether this player is a bot. Defaults to True.
     """
 
-    def decide(self, game, playable_actions):
-        return self.decide_observation(
-            Observation(game, self.color), playable_actions
-        )
+    def __init__(self, agent, is_bot=True):
+        self.agent = agent
+        super().__init__(agent.color, is_bot)
 
-    def decide_observation(self, observation, playable_actions):
-        raise NotImplementedError
+    def decide(self, game, playable_actions):
+        color = self.agent.color
+        observation = Observation(
+            color=color,
+            features=create_sample(game, color),
+            public_history=_sanitize_history(game, color),
+            current_prompt=game.state.current_prompt,
+            current_trade=game.state.current_trade,
+            acceptees=game.state.acceptees,
+        )
+        return self.agent.decide_observation(observation, playable_actions)
+
+    def reset_state(self):
+        self.agent.reset_state()

--- a/catanatron/catanatron/models/perspective_player.py
+++ b/catanatron/catanatron/models/perspective_player.py
@@ -8,9 +8,14 @@ player could observe.
 """
 
 from catanatron.features import create_sample
-from catanatron.models.enums import Action, ActionRecord, ActionType
+from catanatron.models.enums import Action, ActionRecord, ActionType, DEVELOPMENT_CARDS
 from catanatron.models.observation import Observation
 from catanatron.models.player import Player
+from catanatron.state_functions import (
+    player_key,
+    player_num_dev_cards,
+    player_num_resource_cards,
+)
 
 
 def _sanitize_record(record, observer_color):
@@ -39,17 +44,68 @@ def _sanitize_record(record, observer_color):
 def _sanitize_history(game, observer_color):
     """Sanitizes the full-truth action log for the given observer color."""
     return [
-        _sanitize_record(record, observer_color)
-        for record in game.state.action_records
+        _sanitize_record(record, observer_color) for record in game.state.action_records
     ]
+
+
+def _build_public_state(game):
+    """Projects the engine state down to a pure-data snapshot of public facts.
+
+    Everything here is knowable with certainty by every player: the buildings
+    map, roads, robber, longest-road holder, and per-color public counts. It is
+    keyed absolutely (node/edge ids and Colors), unlike ``features`` which is
+    keyed relative to the observing color. Opponent hand identities and actual
+    victory points are never included.
+    """
+    state = game.state
+    board = state.board
+
+    roads = {}
+    for edge, color in board.roads.items():
+        node_a, node_b = edge
+        if node_a < node_b:
+            roads[(node_a, node_b)] = color
+
+    players = {}
+    for color in state.colors:
+        key = player_key(state, color)
+        player_state = state.player_state
+        players[color] = {
+            "public_vps": player_state[f"{key}_VICTORY_POINTS"],
+            "has_army": player_state[f"{key}_HAS_ARMY"],
+            "has_road": player_state[f"{key}_HAS_ROAD"],
+            "longest_road_length": player_state[f"{key}_LONGEST_ROAD_LENGTH"],
+            "roads_left": player_state[f"{key}_ROADS_AVAILABLE"],
+            "settlements_left": player_state[f"{key}_SETTLEMENTS_AVAILABLE"],
+            "cities_left": player_state[f"{key}_CITIES_AVAILABLE"],
+            "has_rolled": player_state[f"{key}_HAS_ROLLED"],
+            "hand_resource_count": player_num_resource_cards(state, color),
+            "hand_dev_count": player_num_dev_cards(state, color),
+        }
+        for card in DEVELOPMENT_CARDS:
+            players[color][f"played_{card.lower()}"] = player_state[
+                f"{key}_PLAYED_{card}"
+            ]
+
+    return {
+        "board": {
+            "buildings": dict(board.buildings),
+            "roads": roads,
+            "robber_coordinate": board.robber_coordinate,
+            "longest_road_color": board.road_color,
+            "longest_road_length": board.road_length,
+        },
+        "players": players,
+    }
 
 
 class PerspectivePlayer(Player):
     """Player that adapts an ObservationAgent into the perfect-info game loop.
 
     On every decision the given game is projected down to the agent's color
-    as an Observation (features, sanitized history, and trade state) and the
-    agent's decide_observation is called. The agent never receives the Game.
+    as an Observation (features, sanitized history, trade state, and a
+    structured public-state snapshot) and the agent's decide_observation is
+    called. The agent never receives the Game.
 
     Args:
         agent (ObservationAgent): the fair agent to drive.
@@ -69,6 +125,7 @@ class PerspectivePlayer(Player):
             current_prompt=game.state.current_prompt,
             current_trade=game.state.current_trade,
             acceptees=game.state.acceptees,
+            public_state=_build_public_state(game),
         )
         return self.agent.decide_observation(observation, playable_actions)
 

--- a/catanatron/catanatron/models/perspective_player.py
+++ b/catanatron/catanatron/models/perspective_player.py
@@ -15,10 +15,17 @@ from catanatron.models.enums import (
     DEVELOPMENT_CARDS,
     RESOURCES,
 )
+from catanatron.models.map import PORT_DIRECTION_TO_NODEREFS
 from catanatron.models.inventory import Inventory
 from catanatron.models.observation import Observation
 from catanatron.models.player import Player
-from catanatron.models.public_state import PublicBoard, PublicPlayer, PublicState
+from catanatron.models.public_state import (
+    PublicBoard,
+    PublicMap,
+    PublicPlayer,
+    PublicState,
+)
+from catanatron.models.trade import PendingTrades, TradeOffer
 from catanatron.state_functions import (
     player_key,
     player_num_dev_cards,
@@ -56,14 +63,42 @@ def _sanitize_history(game, observer_color):
     ]
 
 
+def _build_public_map(board):
+    """Projects the engine's static CatanMap into pure-data form.
+
+    The map never changes during a game, so every decision snapshots the same
+    terrain; it is still projected here so ``Observation`` stays free of any
+    engine reference and works unchanged in site/adapter mode.
+    """
+    catan_map = board.map
+    tiles = {}
+    for tile in catan_map.tiles_by_id.values():
+        tiles[tile.id] = (tile.resource, tile.number)
+    ports = {}
+    for port in catan_map.ports_by_id.values():
+        (a_ref, b_ref) = PORT_DIRECTION_TO_NODEREFS[port.direction]
+        ports[port.id] = (port.resource, (port.nodes[a_ref], port.nodes[b_ref]))
+    adjacent_tiles = {
+        node_id: tuple(t.id for t in tiles_list)
+        for node_id, tiles_list in catan_map.adjacent_tiles.items()
+    }
+    return PublicMap(
+        tiles=tiles,
+        ports=ports,
+        adjacent_tiles=adjacent_tiles,
+        land_nodes=frozenset(catan_map.land_nodes),
+    )
+
+
 def _build_public_state(game):
     """Projects the engine state down to a pure-data snapshot of public facts.
 
     Everything here is knowable with certainty by every player: the buildings
-    map, roads, robber, longest-road holder, and per-color public counts. It is
-    keyed absolutely (node/edge ids and Colors), unlike ``features`` which is
-    keyed relative to the observing color. Opponent hand identities and actual
-    victory points are never included.
+    map, roads, robber, longest-road holder, per-color public counts, and the
+    static board layout. It is keyed absolutely (node/edge/tile ids and
+    Colors), unlike ``features`` which is keyed relative to the observing
+    color. Opponent hand identities and actual victory points are never
+    included.
     """
     state = game.state
     board = state.board
@@ -103,8 +138,39 @@ def _build_public_state(game):
             robber_coordinate=board.robber_coordinate,
             longest_road_color=board.road_color,
             longest_road_length=board.road_length,
+            map=_build_public_map(board),
         ),
         players=players,
+    )
+
+
+def _build_pending_trades(game):
+    """Projects the engine's active trade state into typed TradeOffers.
+
+    The engine holds a single ``current_trade`` slot, so today this yields at
+    most one offer; the tuple shape future-proofs site-mode adapters that allow
+    competing offers. Trades are fully public, so nothing here is redacted.
+    """
+    state = game.state
+    if not state.is_resolving_trade:
+        return PendingTrades()
+
+    last_offer = next(
+        r.action
+        for r in reversed(state.action_records)
+        if r.action.action_type == ActionType.OFFER_TRADE
+    )
+    offered = dict(zip(RESOURCES, state.current_trade[:5]))
+    asking = dict(zip(RESOURCES, state.current_trade[5:10]))
+    return PendingTrades(
+        (
+            TradeOffer(
+                offerer=last_offer.color,
+                offered=offered,
+                asking=asking,
+                acceptees=dict(zip(state.colors, state.acceptees)),
+            ),
+        )
     )
 
 
@@ -122,6 +188,7 @@ def _build_inventory(game, color):
     )
     return Inventory(
         **hand,
+        actual_vps=player_state[f"{key}_ACTUAL_VICTORY_POINTS"],
         has_played_development_card=player_state[
             f"{key}_HAS_PLAYED_DEVELOPMENT_CARD_IN_TURN"
         ],
@@ -152,8 +219,7 @@ class PerspectivePlayer(Player):
             features=create_sample(game, color),
             public_history=_sanitize_history(game, color),
             current_prompt=game.state.current_prompt,
-            current_trade=game.state.current_trade,
-            acceptees=game.state.acceptees,
+            pending_trades=_build_pending_trades(game),
             public_state=_build_public_state(game),
             inventory=_build_inventory(game, color),
         )

--- a/catanatron/catanatron/models/perspective_player.py
+++ b/catanatron/catanatron/models/perspective_player.py
@@ -8,9 +8,17 @@ player could observe.
 """
 
 from catanatron.features import create_sample
-from catanatron.models.enums import Action, ActionRecord, ActionType, DEVELOPMENT_CARDS
+from catanatron.models.enums import (
+    Action,
+    ActionRecord,
+    ActionType,
+    DEVELOPMENT_CARDS,
+    RESOURCES,
+)
+from catanatron.models.inventory import Inventory
 from catanatron.models.observation import Observation
 from catanatron.models.player import Player
+from catanatron.models.public_state import PublicBoard, PublicPlayer, PublicState
 from catanatron.state_functions import (
     player_key,
     player_num_dev_cards,
@@ -70,33 +78,54 @@ def _build_public_state(game):
     for color in state.colors:
         key = player_key(state, color)
         player_state = state.player_state
-        players[color] = {
-            "public_vps": player_state[f"{key}_VICTORY_POINTS"],
-            "has_army": player_state[f"{key}_HAS_ARMY"],
-            "has_road": player_state[f"{key}_HAS_ROAD"],
-            "longest_road_length": player_state[f"{key}_LONGEST_ROAD_LENGTH"],
-            "roads_left": player_state[f"{key}_ROADS_AVAILABLE"],
-            "settlements_left": player_state[f"{key}_SETTLEMENTS_AVAILABLE"],
-            "cities_left": player_state[f"{key}_CITIES_AVAILABLE"],
-            "has_rolled": player_state[f"{key}_HAS_ROLLED"],
-            "hand_resource_count": player_num_resource_cards(state, color),
-            "hand_dev_count": player_num_dev_cards(state, color),
+        played = {
+            f"played_{card.lower()}": player_state[f"{key}_PLAYED_{card}"]
+            for card in DEVELOPMENT_CARDS
         }
-        for card in DEVELOPMENT_CARDS:
-            players[color][f"played_{card.lower()}"] = player_state[
-                f"{key}_PLAYED_{card}"
-            ]
+        players[color] = PublicPlayer(
+            public_vps=player_state[f"{key}_VICTORY_POINTS"],
+            has_army=player_state[f"{key}_HAS_ARMY"],
+            has_road=player_state[f"{key}_HAS_ROAD"],
+            longest_road_length=player_state[f"{key}_LONGEST_ROAD_LENGTH"],
+            roads_left=player_state[f"{key}_ROADS_AVAILABLE"],
+            settlements_left=player_state[f"{key}_SETTLEMENTS_AVAILABLE"],
+            cities_left=player_state[f"{key}_CITIES_AVAILABLE"],
+            has_rolled=player_state[f"{key}_HAS_ROLLED"],
+            hand_resource_count=player_num_resource_cards(state, color),
+            hand_dev_count=player_num_dev_cards(state, color),
+            **played,
+        )
 
-    return {
-        "board": {
-            "buildings": dict(board.buildings),
-            "roads": roads,
-            "robber_coordinate": board.robber_coordinate,
-            "longest_road_color": board.road_color,
-            "longest_road_length": board.road_length,
-        },
-        "players": players,
-    }
+    return PublicState(
+        board=PublicBoard(
+            buildings=dict(board.buildings),
+            roads=roads,
+            robber_coordinate=board.robber_coordinate,
+            longest_road_color=board.road_color,
+            longest_road_length=board.road_length,
+        ),
+        players=players,
+    )
+
+
+def _build_inventory(game, color):
+    """Projects the observing color's private hand into a typed Inventory.
+
+    The observer's own exact resource counts and dev-card identities are
+    knowable only to that color, so this is computed for the observer only.
+    """
+    key = player_key(game.state, color)
+    player_state = game.state.player_state
+    hand = {r.lower(): player_state[f"{key}_{r}_IN_HAND"] for r in RESOURCES}
+    hand.update(
+        {c.lower(): player_state[f"{key}_{c}_IN_HAND"] for c in DEVELOPMENT_CARDS}
+    )
+    return Inventory(
+        **hand,
+        has_played_development_card=player_state[
+            f"{key}_HAS_PLAYED_DEVELOPMENT_CARD_IN_TURN"
+        ],
+    )
 
 
 class PerspectivePlayer(Player):
@@ -126,6 +155,7 @@ class PerspectivePlayer(Player):
             current_trade=game.state.current_trade,
             acceptees=game.state.acceptees,
             public_state=_build_public_state(game),
+            inventory=_build_inventory(game, color),
         )
         return self.agent.decide_observation(observation, playable_actions)
 

--- a/catanatron/catanatron/models/public_state.py
+++ b/catanatron/catanatron/models/public_state.py
@@ -11,9 +11,9 @@ never included.
 """
 
 from dataclasses import dataclass
-from typing import Dict, Optional, Tuple
+from typing import Dict, FrozenSet, Optional, Tuple
 
-from catanatron.models.enums import FastBuildingType
+from catanatron.models.enums import FastBuildingType, FastResource
 from catanatron.models.map import NodeId
 from catanatron.models.player import Color
 
@@ -40,6 +40,26 @@ class PublicPlayer:
 
 
 @dataclass(frozen=True)
+class PublicMap:
+    """Pure-data snapshot of the static board layout.
+
+    The CatanMap (tiles, numbers, ports, terrain nodes) is fixed at game start,
+    so it is snapshotted once per decision rather than changing turn to turn.
+    Keyed absolutely by tile/port/node id, so agents can reason about where
+    things are instead of only parsing the flat ``TILE*``/``PORT*`` features.
+    """
+
+    tiles: Dict[int, Tuple[Optional[FastResource], Optional[int]]]
+    """tile_id -> (resource, roll); desert is (None, None)."""
+    ports: Dict[int, Tuple[Optional[FastResource], Tuple[NodeId, NodeId]]]
+    """port_id -> (resource, (node_a, node_b)) trading nodes; resource None means 3:1."""
+    adjacent_tiles: Dict[NodeId, Tuple[int, ...]]
+    """node_id -> tile ids touching it; edge to per-node production."""
+    land_nodes: FrozenSet[NodeId]
+    """All node ids on land (where settlements may legally be built)."""
+
+
+@dataclass(frozen=True)
 class PublicBoard:
     """Publicly knowable facts about the shared board."""
 
@@ -48,6 +68,8 @@ class PublicBoard:
     robber_coordinate: Tuple[int, int, int]
     longest_road_color: Optional[Color]
     longest_road_length: int
+    map: PublicMap
+    """Static terrain; see ``PublicMap``."""
 
 
 @dataclass(frozen=True)

--- a/catanatron/catanatron/models/public_state.py
+++ b/catanatron/catanatron/models/public_state.py
@@ -1,0 +1,58 @@
+"""
+Typed, pure-data snapshot of everything publicly observable in a game.
+
+These dataclasses mirror the engine's public board and per-player public
+counts, keyed absolutely (node/edge ids and Color), unlike ``features``
+which is keyed relative to the observing color. They are built by the engine
+adapter (``_build_public_state`` in ``perspective_player``) and carried on
+``Observation.public_state``, so fair agents get structured access without any
+Game/State reference. Opponent hand identities and actual victory points are
+never included.
+"""
+
+from dataclasses import dataclass
+from typing import Dict, Optional, Tuple
+
+from catanatron.models.enums import FastBuildingType
+from catanatron.models.map import NodeId
+from catanatron.models.player import Color
+
+
+@dataclass(frozen=True)
+class PublicPlayer:
+    """Publicly knowable facts about one color's position."""
+
+    public_vps: int
+    has_army: bool
+    has_road: bool
+    longest_road_length: int
+    roads_left: int
+    settlements_left: int
+    cities_left: int
+    has_rolled: bool
+    hand_resource_count: int
+    hand_dev_count: int
+    played_knight: int
+    played_monopoly: int
+    played_road_building: int
+    played_year_of_plenty: int
+    played_victory_point: int
+
+
+@dataclass(frozen=True)
+class PublicBoard:
+    """Publicly knowable facts about the shared board."""
+
+    buildings: Dict[NodeId, Tuple[Color, FastBuildingType]]
+    roads: Dict[Tuple[NodeId, NodeId], Color]
+    robber_coordinate: Tuple[int, int, int]
+    longest_road_color: Optional[Color]
+    longest_road_length: int
+
+
+@dataclass(frozen=True)
+class PublicState:
+    """Pure-data snapshot of every public fact in a State."""
+
+    board: PublicBoard
+    players: Dict[Color, PublicPlayer]

--- a/catanatron/catanatron/models/public_state.py
+++ b/catanatron/catanatron/models/public_state.py
@@ -13,6 +13,7 @@ never included.
 from dataclasses import dataclass
 from typing import Dict, FrozenSet, Optional, Tuple
 
+from catanatron.models.coordinate_system import Coordinate
 from catanatron.models.enums import FastBuildingType, FastResource
 from catanatron.models.map import NodeId
 from catanatron.models.player import Color
@@ -51,6 +52,8 @@ class PublicMap:
 
     tiles: Dict[int, Tuple[Optional[FastResource], Optional[int]]]
     """tile_id -> (resource, roll); desert is (None, None)."""
+    tile_coordinates: Dict[int, Coordinate]
+    """tile_id -> its cube coordinate; bridges id-keyed tiles to coordinate-keyed actions."""
     ports: Dict[int, Tuple[Optional[FastResource], Tuple[NodeId, NodeId]]]
     """port_id -> (resource, (node_a, node_b)) trading nodes; resource None means 3:1."""
     adjacent_tiles: Dict[NodeId, Tuple[int, ...]]
@@ -65,7 +68,8 @@ class PublicBoard:
 
     buildings: Dict[NodeId, Tuple[Color, FastBuildingType]]
     roads: Dict[Tuple[NodeId, NodeId], Color]
-    robber_coordinate: Tuple[int, int, int]
+    robber_tile_id: int
+    """Id of the tile the robber sits on, resolvable to/from a coordinate via ``map.tile_coordinates``."""
     longest_road_color: Optional[Color]
     longest_road_length: int
     map: PublicMap

--- a/catanatron/catanatron/models/trade.py
+++ b/catanatron/catanatron/models/trade.py
@@ -1,0 +1,65 @@
+"""
+Typed, pure-data snapshot of a pending trade offer.
+
+The engine stores trades as raw positional tuples on ``State`` (``current_trade``
+plus a parallel ``acceptees`` tuple), which is hostile to an agent that wants to
+reason about *what* is being traded and with whom. This object re-keys that info
+by resource and color so the ObservationAgent sees the offer structurally.
+"""
+
+from dataclasses import dataclass
+from typing import Dict, Iterator, Optional, Tuple, Union
+
+from catanatron.models.enums import FastResource
+from catanatron.models.player import Color
+
+
+@dataclass(frozen=True)
+class TradeOffer:
+    """One offer that is currently on the table, awaiting responses.
+
+    Only public facts appear: a trade is fully public in Catan.
+    """
+
+    offerer: Color
+    """Color that made the offer."""
+    offered: Dict[FastResource, int]
+    """Resource -> count the offerer gives up."""
+    asking: Dict[FastResource, int]
+    """Resource -> count the offerer wants in return."""
+    acceptees: Dict[Color, bool]
+    """Color -> whether that color has accepted; the offerer is always False."""
+
+
+@dataclass(frozen=True)
+class PendingTrades:
+    """Immutable container for the trades currently on the table.
+
+    Wrapping the underlying collection in an object makes the snapshot's
+    read-only nature explicit and lets the internal storage change (tuple,
+    list, tree) without touching consumers. Behaves like a tuple for iteration
+    and indexing.
+    """
+
+    offers: Tuple[TradeOffer, ...] = ()
+
+    def __iter__(self) -> Iterator[TradeOffer]:
+        return iter(self.offers)
+
+    def __len__(self) -> int:
+        return len(self.offers)
+
+    def __getitem__(self, index) -> Union[TradeOffer, Tuple[TradeOffer, ...]]:
+        return self.offers[index]
+
+    @property
+    def is_active(self) -> bool:
+        """True when at least one offer is on the table."""
+        return bool(self.offers)
+
+    @property
+    def single(self) -> Optional[TradeOffer]:
+        """The lone offer in engine mode (today at most one fits), else None."""
+        if len(self.offers) != 1:
+            return None
+        return self.offers[0]

--- a/designs/perspective-player-and-observation.md
+++ b/designs/perspective-player-and-observation.md
@@ -145,9 +145,17 @@ public_state = {
     "board": {
         "buildings": {node_id: (color, building_type)},  # current buildings
         "roads": {(n1, n2): color},                      # canonical orientation
-        "robber_coordinate": (x, y, z),
+        "robber_tile_id": int,  # tile id of the robber's tile; resolve to/from a
+        #              coordinate via board.map.tile_coordinates
         "longest_road_color": color | None,
         "longest_road_length": int,
+        "map": {
+            "tiles": {tile_id: (resource, roll)},
+            "tile_coordinates": {tile_id: (x, y, z)},  # id <-> coordinate bridge
+            "ports": {port_id: (resource, (node_a, node_b))},
+            "adjacent_tiles": {node_id: (tile_id, ...)},
+            "land_nodes": frozenset(node_id),
+        },
     },
     "players": {  # one entry per color, public facts only
         Color.RED: {
@@ -164,7 +172,7 @@ public_state = {
 }
 ```
 
-Invariants mirror the tiers (§3.1): only **public** facts appear — opponent hand identities and `ACTUAL_VICTORY_POINTS` are never projected. Like `features`, it is eager (once per decision) and pure data (no `Game`/`State` reference, so the fairness contract holds). The static `CatanMap` (tiles/numbers/adjacency/ports) is also snapshotted here as `public_state.board.map` (`PublicMap`: tiles by id with resource+roll, ports by id with resource+node ids, per-node `adjacent_tiles`, and `land_nodes`), giving fair agents structured, absolute-keyed access to the terrain instead of only the flat `TILE*`/`PORT*` feature keys. Derived probabilities are **not** stored — per-node production is inferred from tile rolls plus adjacency — keeping the snapshot raw facts only. It is static, so every decision snapshots identical terrain; the projection exists solely to keep `Observation` free of engine references.
+Invariants mirror the tiers (§3.1): only **public** facts appear — opponent hand identities and `ACTUAL_VICTORY_POINTS` are never projected. Like `features`, it is eager (once per decision) and pure data (no `Game`/`State` reference, so the fairness contract holds). The static `CatanMap` (tiles/numbers/adjacency/ports) is also snapshotted here as `public_state.board.map` (`PublicMap`: tiles by id with resource+roll, `tile_coordinates` bridging tile ids to/from cube coordinates (the format `MOVE_ROBBER` action values use), ports by id with resource+node ids, per-node `adjacent_tiles`, and `land_nodes`), giving fair agents structured, absolute-keyed access to the terrain instead of only the flat `TILE*`/`PORT*` feature keys. Derived probabilities are **not** stored — per-node production is inferred from tile rolls plus adjacency — keeping the snapshot raw facts only. It is static, so every decision snapshots identical terrain; the projection exists solely to keep `Observation` free of engine references.
 
 ### 3.3 `public_history` — sanitized action log
 
@@ -271,7 +279,7 @@ Unit-testable invariants:
 `tests/test_observation.py` coverage:
 - **Structural separation tests:** `ObservationAgent` is not a `Player`; `Observation` is pure data with no `_game`/`state`.
 - **Leak-invariant test** (`scan` over `features` + `public_state` + `public_history` across seeded full games): forbids opponent `*_IN_HAND`, opponent `ACTUAL_VICTORY_POINTS`, opponent `BUY_DEVELOPMENT_CARD` value/result, and (for spectators) `MOVE_ROBBER` stolen-card identities.
-- **`public_state` surface tests:** each decision's snapshot exactly matches the engine board (`buildings`, canonical `roads`, `robber_coordinate`, longest road, static `map` tiles/ports/adjacency) and per-player public counts, verified against the state it was projected from.
+- **`public_state` surface tests:** each decision's snapshot exactly matches the engine board (`buildings`, canonical `roads`, `robber_tile_id` (resolvable to/from coordinate via `map.tile_coordinates`), longest road, static `map` tiles/ports/adjacency) and per-player public counts, verified against the state it was projected from.
 - **Participant test:** the victim of a steal *does* see the stolen card in `public_history`; a spectator does not.
 - **Sanitizer unit tests** per row of the table in §3.3.
 - **Seam tests:** `Game([PerspectivePlayer(bot), RandomPlayer, ...])` plays to completion; bare `ObservationAgent`s driven through the `decide_fn` seam; `reset_state()` delegation.

--- a/designs/perspective-player-and-observation.md
+++ b/designs/perspective-player-and-observation.md
@@ -1,0 +1,313 @@
+# ADR: `ObservationAgent` / `PerspectivePlayer` / `Observation` — imperfect-information play
+
+- **Status:** Proposed
+- **Scope:** `catanatron` (Python >=3.11, GPL-3.0)
+- **Related code:**
+  - `catanatron/models/player.py` — `Player` (l.19), `decide` (l.37), `reset_state` (l.47)
+  - `catanatron/models/enums.py` — `Action` (l.113), `ActionType` (l.68), `ActionPrompt` (l.58), `ActionRecord` (l.126)
+  - `catanatron/state.py` — `State`, `player_state`, `action_records` (l.124)
+  - `catanatron/state_functions.py` — `player_key` (l.74)
+  - `catanatron/features.py` — `player_features` (l.53), `resource_hand_features` (l.85), `create_sample` (l.517), `create_sample_vector` (l.524)
+  - `catanatron/game.py` — `Game.play` (l.132), `play_tick` (l.153), `execute` (l.179), `copy` (l.214), `is_valid_action` (l.22)
+  - `catanatron/apply_action.py` — rewrites of `Action.value` that leak hidden info (l.254, l.316, l.266)
+  - `catanatron/models/board.py` — `Board` (l.39)
+  - `catanatron/cli/cli_players.py` — `register_cli_player` (l.86), `parse_cli_string` (l.70)
+  - `catanatron/cli/play.py` — `--code` module loading (l.181)
+  - `tests/` — repo test root; new `tests/test_observation.py`
+
+## 1. Context & motivation
+
+Catanatron's `Player.decide(game, playable_actions)` hands every bot the **full-truth `Game`**. That is correct for self-play, training, and offline analysis — but it makes the shipped bots (MCTS, AlphaBeta, ...) **cheaters** against real humans: a bot that can read `state.player_state["P1_WOOD_IN_HAND"]` or an opponent's hidden `ACTUAL_VICTORY_POINTS` has an information advantage no human has.
+
+We want an opt-in, backward-compatible layer so a bot can play against humans *fairly* — it must only perceive what a real player can observe. The engine keeps full truth for simulation.
+
+**Core principle.** An `Observation` is the bot's **entire information world**. It is *not necessarily* a projection of a perfect-information `Game`:
+
+- **Local / engine mode:** the engine holds full truth; `PerspectivePlayer` projects it down to what is fair. This is where testing, self-play, sampling, and future search-under-uncertainty live.
+- **Deployed / site mode:** the bot is a client of an external Catan site. There is **no `Game` object anywhere** — the only data is what the site feeds (own hand, public board, public events). The observation *is* the representation.
+
+The whole design therefore converges on one seam: **bot logic may depend only on the `Observation` surface**, never on `Game`. The same agent runs against a local engine or a future site adapter that feeds observations from external events.
+
+The current `Player.decide` conflates *perception* (what the agent is told) with *simulation* (the ability to `game.copy()` + `execute()` for search). This split uncouples them.
+
+## 2. Decision
+
+Add three plain classes with **zero breaking changes** to the existing engine:
+
+- `ObservationAgent` — a pure, deployment-agnostic agent base. Decides from an `Observation`, never a `Game`. Not a `Player`.
+- `PerspectivePlayer(Player)` — the engine-side **adapter**. Wraps an `ObservationAgent`; on every decision it projects the perfect-information `game` down to the agent's color as an `Observation` and forwards. This is the only engine-coupled piece.
+- `Observation` — a **pure-data, read-only snapshot** of exactly one color's information world. Holds no reference to `Game` or `State`.
+
+The game loop always requires a perfect-information state, so a fair agent *must* be wrapped by a `Player` subclass that converts the `game` parameter into an observation. The engine (`Player`, `Game`, `State`, `Action`, `generate_playable_actions`, `GameAccumulator`) is untouched; the split exists only at the decision boundary.
+
+```python
+# catanatron/models/observation_agent.py
+class ObservationAgent:
+    """Base class for agents that only ever perceive Observations."""
+
+    def __init__(self, color):
+        self.color = color
+
+    def decide_observation(self, observation, playable_actions):
+        raise NotImplementedError
+
+    def reset_state(self):
+        """Hook for resetting memory between games."""
+        pass
+
+
+# catanatron/models/perspective_player.py
+class PerspectivePlayer(Player):
+    """Player that adapts an ObservationAgent into the perfect-info game loop."""
+
+    def __init__(self, agent, is_bot=True):
+        self.agent = agent
+        super().__init__(agent.color, is_bot)
+
+    def decide(self, game, playable_actions):
+        color = self.agent.color
+        observation = Observation(
+            color=color,
+            features=create_sample(game, color),
+            public_history=_sanitize_history(game, color),
+            current_prompt=game.state.current_prompt,
+            current_trade=game.state.current_trade,
+            acceptees=game.state.acceptees,
+            public_state=_build_public_state(game),
+        )
+        return self.agent.decide_observation(observation, playable_actions)
+
+    def reset_state(self):
+        self.agent.reset_state()
+```
+
+`reset_state()` lives on the agent (no-op hook, game-agnostic) and is delegated to by the adapter. It is *not* inherited from `Player`.
+
+**File placement.** Six files in `catanatron/models/`:
+
+| File | Contents |
+|---|---|
+| `player.py` | `Player`, `SimplePlayer`, `HumanPlayer`, `RandomPlayer` — **untouched** |
+| `observation.py` | `Observation` — pure data, no engine imports |
+| `observation_agent.py` | `ObservationAgent` — pure agent, no engine imports |
+| `trade.py` | `TradeOffer` + `PendingTrades` — typed, pure-data trade snapshots |
+| `public_state.py` | `PublicState`/`PublicBoard`/`PublicMap`/`PublicPlayer` — typed, pure-data public snapshots |
+| `inventory.py` | `Inventory` — typed, pure-data private-hand snapshot |
+| `perspective_player.py` | `PerspectivePlayer(Player)` + the `public_history` sanitizer + the `public_state`/`trade`/`inventory` projectors (`_build_public_state`, `_build_pending_trades`, `_build_inventory`) |
+
+All new classes are plain classes (no `Protocol`/`ABC`), matching the repo's existing style. The import graph is acyclic: `observation.py` / `observation_agent.py` depend only on `models.player` (stdlib-only); `perspective_player.py` → `observation.py` + `features.py`/`game.py` + `models.player`. Only `perspective_player.py` couples to the engine.
+
+## 3. `Observation` API
+
+```python
+# catanatron/models/observation.py
+@dataclass(frozen=True)
+class Observation:
+    color: Color
+    features: Optional[Dict[str, Any]] = None  # optional; RL-vector surface only
+    public_history: Tuple[ActionRecord, ...] = ()
+    current_prompt: Optional[ActionPrompt] = None
+    pending_trades: PendingTrades = PendingTrades()
+    public_state: Optional[PublicState] = None
+    inventory: Optional[Inventory] = None
+
+    @property
+    def own(self):  # the observer's own PublicPlayer, for obs.own.public_vps
+        return self.public_state.players[self.color] if self.public_state else None
+```
+
+`Observation` is constructed with precomputed data and is immutable by convention. The extraction from the full-truth `Game` happens **in `PerspectivePlayer`**, eagerly, once per decision.
+
+### 3.1 Tiers
+
+**`own` — private (yours):** hand counts per resource, dev cards in hand, own `ACTUAL_VICTORY_POINTS` (you know your own hidden VP cards; carried on `Observation.inventory.actual_vps`), own buildings, buildable nodes/edges, `has_rolled`, ports owned.
+
+**`public` — known with certainty, including derived counts:** board (buildings map, roads, robber, `CatanMap` tiles/numbers/adjacency/production/ports), per-player `public_vps`, `has_road`, `has_army`, `longest_road_length`, `roads/settlements/cities_left`, `knights_played`, `num_resources` and `num_devs` hand/dev-card **counts** (public in real Catan; already exposed by `resource_hand_features`), and a filtered `public_history` (below).
+
+**`revelations` — composition-evidence only (for belief-state):** discards on a 7 (count public), steals `(stealer, victim)` (card identity hidden), dev-card purchases (count public, identity hidden), trades with exact cards (fully public).
+
+**Never exposed:** opponent `*_IN_HAND` per-resource/per-dev fields, opponent `ACTUAL_VICTORY_POINTS`, stolen/discarded card identities for non-participants, which dev card an opponent drew.
+
+### 3.2 `features` — projection via the existing RL extractors
+
+The flat feature dict is built by reusing `features.create_sample(game, p0_color)`, which is *already* an imperfect-information-shaped snapshot: `P0_ACTUAL_VPS` only for yourself, `P0_*_IN_HAND` only for yourself, per-player public counts (`P{i}_NUM_RESOURCES_IN_HAND`, `P{i}_NUM_DEVS_IN_HAND`, `P{i}_*_PLAYED`, `P{i}_PUBLIC_VPS`, board features), all keyed relative to `P0` = the observing color.
+
+`create_sample` is called by `PerspectivePlayer.decide` and the resulting dict is stored on `Observation.features`. It is **eager** (computed once per real decision) rather than lazy: this is what allows `Observation` to hold no `Game` reference. The cost is negligible — `create_sample` runs at decision time, never inside the MCTS/playout hot path (which uses `game.copy()`).
+
+`features` is optional on the `Observation` (defaults to `None`): it exists for compatibility with the RL training loop and is not part of the agent's core information world (`public_state` + `pending_trades` + `inventory` + `current_prompt` carry the same facts in typed form).
+
+### 3.2.1 `public_state` — structured access to public state
+
+`features` is flat, P0-relative, and schema-encoded — fine for RL vectors, hostile to an agent that wants to reason about *where* things are. The engine gives `Player` a structured `Board` (`game.state.board.buildings`, `.roads`, `.robber_coordinate`) that the `ObservationAgent` has no access to. To close that gap, `Observation.public_state` carries a pure-data snapshot of **every public fact in `State`**, keyed absolutely (node/edge ids and `Color`), built by `_build_public_state(game)` in `PerspectivePlayer`:
+
+```python
+public_state = {
+    "board": {
+        "buildings": {node_id: (color, building_type)},  # current buildings
+        "roads": {(n1, n2): color},                      # canonical orientation
+        "robber_coordinate": (x, y, z),
+        "longest_road_color": color | None,
+        "longest_road_length": int,
+    },
+    "players": {  # one entry per color, public facts only
+        Color.RED: {
+            "public_vps": int, "has_army": bool, "has_road": bool,
+            "longest_road_length": int, "roads_left": int,
+            "settlements_left": int, "cities_left": int, "has_rolled": bool,
+            "hand_resource_count": int, "hand_dev_count": int,
+            "played_knight": int, "played_monopoly": int,
+            "played_road_building": int, "played_year_of_plenty": int,
+            "played_victory_point": int,
+        },
+        ...
+    },
+}
+```
+
+Invariants mirror the tiers (§3.1): only **public** facts appear — opponent hand identities and `ACTUAL_VICTORY_POINTS` are never projected. Like `features`, it is eager (once per decision) and pure data (no `Game`/`State` reference, so the fairness contract holds). The static `CatanMap` (tiles/numbers/adjacency/ports) is also snapshotted here as `public_state.board.map` (`PublicMap`: tiles by id with resource+roll, ports by id with resource+node ids, per-node `adjacent_tiles`, and `land_nodes`), giving fair agents structured, absolute-keyed access to the terrain instead of only the flat `TILE*`/`PORT*` feature keys. Derived probabilities are **not** stored — per-node production is inferred from tile rolls plus adjacency — keeping the snapshot raw facts only. It is static, so every decision snapshots identical terrain; the projection exists solely to keep `Observation` free of engine references.
+
+### 3.3 `public_history` — sanitized action log
+
+`State.action_records` is full truth. The engine **rewrites `Action.value`** for some actions, so hidden identities sit in `action.value`, not just `ActionRecord.result`:
+
+- `apply_buy_development_card` → `Action(..., card)` (apply_action.py:254)
+- `apply_discard` → `Action(..., discarded_resource)` (apply_action.py:316)
+- `apply_roll` → `Action(..., dice)` — dice are public (apply_action.py:266)
+- `apply_move_robber` → `action.value = (coordinate, robbed_color)`, `result = robbed_resource`
+
+Therefore sanitization is **keyed on `action_type` plus participation**, never on "is `result` non-None". It lives in `perspective_player.py` (`_sanitize_history`/`_sanitize_record`):
+
+| Opponent record | `public_history` exposes | Reasoning |
+|---|---|---|
+| `BUY_DEVELOPMENT_CARD` | purchase only; `value` and `result` redacted to `None` | identity is the private fact; redact both channels |
+| `MOVE_ROBBER` | `value` `(coordinate, robbed_color)`; `result` redacted to `None` **unless observer is the victim** | participants know the card, spectators do not |
+| `DISCARD_RESOURCE` | full identity | public per tournament convention (see assumption below) |
+| everything else | pass through unchanged | rolls, builds, trades are public |
+
+For the observer's own records, full detail is retained (it is their own private information; the fairness contract is unaffected).
+
+**Assumption (documented):** discards are treated as **public** — the official rules/FAQ do not state discard privacy; physically cards return to the face-up supply, and tournament play treats discards as public. If a future deployment targets house rules with face-down discards, this is a single sanitizer switch (`discards_public=True`).
+
+### 3.4 Trade representation
+
+Trades are **completely public**: `OFFER_TRADE`'s 10-tuple, `state.current_trade`, `acceptees`, and `CONFIRM_TRADE`'s accepting color carry zero hidden info. Decisions are already fully encoded in `playable_actions` (`ACCEPT_TRADE`/`REJECT_TRADE` embed `current_trade` in `.value`; `CONFIRM_TRADE` embeds offer + acceptor).
+
+Rather than expose the engine's raw positional `current_trade` tuple plus a parallel `acceptees` tuple, `Observation` carries `pending_trades: PendingTrades`, an immutable container for the trades on the table. Each `TradeOffer` re-keys that info structurally:
+
+```python
+@dataclass(frozen=True)
+class TradeOffer:
+    offerer: Color
+    offered: Dict[FastResource, int]   # resource -> count given up
+    asking: Dict[FastResource, int]    # resource -> count wanted
+    acceptees: Dict[Color, bool]       # color -> has accepted (offerer always False)
+
+@dataclass(frozen=True)
+class PendingTrades:
+    offers: Tuple[TradeOffer, ...] = ()
+    # iterable/indexable like a tuple; frozen so the set of offers is read-only
+    # convenience accessors: .is_active, .single (the lone offer in engine mode)
+```
+
+The engine's `State` holds a single `current_trade` slot (`apply_action.py:441-515`), so today the container holds zero or one offer; the container future-proofs site-mode rules that allow competing offers simultaneously. Built by `_build_pending_trades` in `perspective_player.py`, which reads the last `OFFER_TRADE` record for the offerer (the engine stores a turn *index*, not the color).
+
+`Observation` also carries `current_prompt` so bots need not dig through `playable_actions` to know what is being asked of them. Generating your own `OFFER_TRADE` needs `has_rolled`, available in the `own` tier via `features["P0_HAS_ROLLED"]`.
+
+### 3.5 Presentation-free
+
+`Observation` contains **no `describe`/`render` logic** — it is a lean, data-only snapshot. A standalone text helper (e.g. `observation_to_text(obs)`) may be added later for LLM and `HumanPlayer` consumers.
+
+### 3.6 Hard boundary
+
+`Observation` holds **no reference to `Game` or `State`** — not even privately, and not "a copy for simulation." This is what makes the fairness contract structural: there is no handle to leak. A future belief-state hook must build a *fresh* complete game from sampled hidden info, never from the observation.
+
+## 4. Integration map
+
+All seams work unchanged:
+
+```python
+# Library
+game = Game(
+    [
+        PerspectivePlayer(CardCounterBot(Color.RED)),
+        HumanPlayer(Color.BLUE),
+        RandomPlayer(Color.ORANGE),
+    ]
+)
+winner = game.play()
+
+# CLI (register_cli_player) → catanatron-play --code myfile.py --players CC,R,R,R
+from catanatron.cli.cli_players import register_cli_player
+register_cli_player("CC", lambda color: PerspectivePlayer(CardCounterBot(color)))
+
+# Ad-hoc decide_fn seam (play_tick calls decide_fn(player, game, playable_actions))
+# drives bare ObservationAgents directly, no wrapper needed:
+game.play(decide_fn=lambda agent, g, actions: agent.decide_observation(
+    Observation(
+        color=agent.color,
+        features=create_sample(g, agent.color),
+        public_history=_sanitize_history(g, agent.color),
+        current_prompt=g.state.current_prompt,
+        pending_trades=_build_pending_trades(g),
+        public_state=_build_public_state(g),
+    ),
+    actions,
+))
+
+# reset_state() delegated from PerspectivePlayer to its agent
+```
+
+`json.py` / replay / accumulators are **untouched**: full-truth serialization is the engine's business (replay reconstructs hidden state from `action_record.result`). This ADR does not change it.
+
+## 5. Fairness contract
+
+Unit-testable invariants:
+
+1. **Structural:** an `ObservationAgent` never receives a `Game` or `State` — only `Observation` (type-enforced at the only `game`-touching site, `PerspectivePlayer.decide`). The agent is *not* a `Player` and exposes no `decide(game, ...)` / `is_bot`.
+2. **Counts reachable, identities not:** for every opponent, resource/dev-card hand *counts* are reachable from the observation surface; per-resource/per-dev hand *identities* are not.
+3. **Hidden fields absent:** opponent `ACTUAL_VICTORY_POINTS`, non-participant stolen-card identities, and non-buyer drawn-dev-card identities are absent from the entire exposed surface; `Observation` carries no `_game`/`state` attribute at all.
+4. **`public_state`/`pending_trades` are public-only:** the structured snapshots mirror the engine's board/per-player public fields exactly (§3.2.1) and the typed trade offers; both are scanned by the leak-invariant test alongside `features`.
+
+`tests/test_observation.py` coverage:
+- **Structural separation tests:** `ObservationAgent` is not a `Player`; `Observation` is pure data with no `_game`/`state`.
+- **Leak-invariant test** (`scan` over `features` + `public_state` + `public_history` across seeded full games): forbids opponent `*_IN_HAND`, opponent `ACTUAL_VICTORY_POINTS`, opponent `BUY_DEVELOPMENT_CARD` value/result, and (for spectators) `MOVE_ROBBER` stolen-card identities.
+- **`public_state` surface tests:** each decision's snapshot exactly matches the engine board (`buildings`, canonical `roads`, `robber_coordinate`, longest road, static `map` tiles/ports/adjacency) and per-player public counts, verified against the state it was projected from.
+- **Participant test:** the victim of a steal *does* see the stolen card in `public_history`; a spectator does not.
+- **Sanitizer unit tests** per row of the table in §3.3.
+- **Seam tests:** `Game([PerspectivePlayer(bot), RandomPlayer, ...])` plays to completion; bare `ObservationAgent`s driven through the `decide_fn` seam; `reset_state()` delegation.
+
+The invariant test scans the **output surface** (not implementation), so it stays valid if projection internals change.
+
+**Deferred:** a "fair bot vs full-info bot" win-rate benchmark. It is meaningless with a trivial test bot and belongs to a follow-up once a real fair bot exists.
+
+## 6. Performance
+
+- Constructing an `Observation` is O(1) — it stores precomputed data and a color.
+- `public_state` projection is O(board + players) per decision and builds only plain dicts/tuples — negligible next to `create_sample`.
+- `features` is computed **once per decision**, eagerly, in `PerspectivePlayer.decide`. The MCTS/playout hot path — which performs thousands of `copy()`s — never constructs an `Observation`.
+- `public_history` sanitization runs once per decision and is O(history length); it is cheap enough per decision.
+
+## 7. Consequences & tradeoffs
+
+- **Additive API surface.** Existing `Player`-based code paths are untouched and still work; perfect bots remain full-information by design.
+- **Structural fairness** replaces "trust the bot to be honest." An `ObservationAgent` cannot receive the `Game` — the only `game`-touching site is the `PerspectivePlayer` adapter, and `Observation` carries no engine handle — so the fair contract is enforceable, not a promise.
+- **Belief-state / search-under-uncertainty (contract defined, not implemented).** A future hook `ObservationAgent.sample_hidden_state(obs) -> Game` will let fair agents run the shipped perfect bots (MCTS, AlphaBeta) on their **own sampled hypotheses** of hidden state. Invariant: it returns a fresh, consistent game built only from the observation — never the wrapped `_game`. Deliberately deferred: the construction plumbing is non-trivial and there is no v1 consumer.
+- **`HumanPlayer` unchanged (out of scope).** A human cannot read the `Game` object — they already only perceive their own hand and the board — so there is no fairness benefit in re-plumbing them. Flagged as a future adapter target.
+- **Deployed-play implications.** On a real Catan site there is no perfect-information representation; game "replays" are observation logs, not full-truth. Because `Observation` is pure data, a site adapter can build the *same* object from external events and drive the *same* `ObservationAgent`. Future work: an **observation-log serializer** (record `features` + `public_history` per decision for analysis/ML on real-site games) and a **site adapter** that feeds external events through `decide_observation`. The framework's contract (§5) is what makes both buildable later without redesign.
+- **Assumption on discards.** Treated as public (tournament convention). A future house-rules deployment can flip a single sanitizer switch.
+
+## 8. Resolved open questions
+
+| # | Question | Decision |
+|---|---|---|
+| 1 | Module placement / Protocol-ABC? | Four files: `models/player.py` (untouched), `models/observation.py`, `models/observation_agent.py`, `models/perspective_player.py`. Plain classes, no Protocol/ABC. Only `perspective_player.py` imports the engine. |
+| 2 | Is `PerspectivePlayer` a subclass of `Player`? | **No** for the agent, **yes** for the adapter. `ObservationAgent` is deliberately *not* a `Player` (it is not-a full-truth decider, it is engine-independent, and it carries no `decide(game, ...)`); `PerspectivePlayer` *is* a `Player` because the game loop requires a perfect-info state and the adapter's job is to convert it into an observation. |
+| 3 | Where does `create_sample` live? | In `PerspectivePlayer` (eager, once per decision), not on `Observation` — so `Observation` is pure data and free of `Game`/`State`. |
+| 4 | `public_history` filtering? | Keyed on `action_type` + participant (§3.3). Redact both `action.value` and `result` for opponent `BUY_DEV`; redact `result` for `MOVE_ROBBER` unless victim; discards public. Lives in `perspective_player.py`. |
+| 5 | Belief-state hook now or defer? | Contract in this ADR only; zero v1 implementation; future work. |
+| 6 | Trade sub-prompts / describe-render? | Trades fully public; `Observation` carries `current_prompt` + typed `pending_trades: PendingTrades` (immutable container of `TradeOffer`, each re-keyed by resource and color). No `describe`/render in `Observation`. The engine allows one offer at a time today; the container future-proofs competing offers. |
+| 7 | `reset_state()`? | Lives on the agent as a no-op hook; `PerspectivePlayer.reset_state` delegates. Not inherited from `Player`. |
+| 8 | `HumanPlayer` perspective view? | Out of scope for v1; future adapter candidate. |
+| 9 | Test strategy? | `tests/test_observation.py`: structural separation + leak-invariant surface scan (features + public_state + pending_trades + public_history) + participant + sanitizer-table + trade-object + seam tests; win-rate benchmark deferred. |
+| 10 | `json.py`/replay/accumulators? | Untouched. Observation-log serialization and site adapter are future work. |
+| 11 | Structured public-state access for agents? | `Observation.public_state`: a pure-data, absolute-keyed snapshot of all public facts (board buildings/roads/robber/longest road + per-color public counts + the static map as `board.map`), built eagerly by `_build_public_state` in `perspective_player.py`. Complements the P0-relative flat `features`; the `CatanMap` is included as a structured `PublicMap` (raw tile rolls/ports/adjacency, no derived probabilities) so agents can reason about the terrain, not just parse `TILE*`/`PORT*` keys. |

--- a/tests/test_observation.py
+++ b/tests/test_observation.py
@@ -240,7 +240,9 @@ def _play_recorded_game(seed=0):
                 "colors": tuple(g.state.colors),
                 "buildings": dict(g.state.board.buildings),
                 "roads": dict(g.state.board.roads),
-                "robber_coordinate": g.state.board.robber_coordinate,
+                "robber_tile_id": g.state.board.map.tiles[
+                    g.state.board.robber_coordinate
+                ].id,
                 "road_color": g.state.board.road_color,
                 "road_length": g.state.board.road_length,
                 "player_state": dict(g.state.player_state),
@@ -259,7 +261,7 @@ def test_public_state_matches_engine_board():
         assert isinstance(obs.public_state, PublicState)
         public_board = obs.public_state.board
         assert isinstance(public_board, PublicBoard)
-        assert public_board.robber_coordinate == snap["robber_coordinate"]
+        assert public_board.robber_tile_id == snap["robber_tile_id"]
         assert public_board.longest_road_color == snap["road_color"]
         assert public_board.longest_road_length == snap["road_length"]
         assert public_board.buildings == snap["buildings"]
@@ -297,10 +299,29 @@ def test_public_state_map_matches_engine_map():
         node_id: tuple(t.id for t in tiles_list)
         for node_id, tiles_list in engine_map.adjacent_tiles.items()
     }
+    from catanatron.models.tiles import LandTile
+
+    expected_tile_coordinates = {
+        tile.id: coordinate
+        for coordinate, tile in engine_map.tiles.items()
+        if isinstance(tile, LandTile)
+    }
     assert public_map.tiles == expected_tiles
+    assert public_map.tile_coordinates == expected_tile_coordinates
     assert public_map.ports == expected_ports
     assert public_map.adjacent_tiles == expected_adjacency
     assert public_map.land_nodes == frozenset(engine_map.land_nodes)
+
+    for tile_id, coordinate in public_map.tile_coordinates.items():
+        assert tile_id in public_map.tiles
+        assert engine_map.tiles[coordinate].id == tile_id
+
+    coordinate_to_tile = {
+        coord: tile_id for tile_id, coord in public_map.tile_coordinates.items()
+    }
+    robber_coord = game.state.board.robber_coordinate
+    assert public_map.tile_coordinates[state.board.robber_tile_id] == robber_coord
+    assert coordinate_to_tile[robber_coord] == state.board.robber_tile_id
 
     for tile_id, (resource, number) in public_map.tiles.items():
         assert 0 <= tile_id < len(engine_map.tiles_by_id)
@@ -377,7 +398,10 @@ def test_build_public_state_is_standalone():
     state = _build_public_state(game)
     assert isinstance(state, PublicState)
     assert state.board.buildings == {}
-    assert state.board.robber_coordinate == game.state.board.robber_coordinate
+    assert (
+        state.board.robber_tile_id
+        == game.state.board.map.tiles[game.state.board.robber_coordinate].id
+    )
     assert set(state.players.keys()) == set(game.state.colors)
 
 

--- a/tests/test_observation.py
+++ b/tests/test_observation.py
@@ -2,6 +2,7 @@ import re
 
 import pytest
 
+from catanatron.features import create_sample
 from catanatron.game import Game
 from catanatron.models.enums import (
     DEVELOPMENT_CARDS,
@@ -11,15 +12,20 @@ from catanatron.models.enums import (
     ActionType,
 )
 from catanatron.models.observation import Observation
-from catanatron.models.perspective_player import PerspectivePlayer
-from catanatron.models.player import Color, RandomPlayer
+from catanatron.models.observation_agent import ObservationAgent
+from catanatron.models.perspective_player import (
+    PerspectivePlayer,
+    _sanitize_history,
+    _sanitize_record,
+)
+from catanatron.models.player import Color, Player, RandomPlayer
 
 
-class RecorderPlayer(PerspectivePlayer):
+class RecorderAgent(ObservationAgent):
     """Trivial fair bot that records every Observation it receives."""
 
     def __init__(self, color):
-        super().__init__(color, is_bot=True)
+        super().__init__(color)
         self.observations = []
         self.calls_since_reset = 0
 
@@ -57,87 +63,96 @@ def _make_game(*players, seed=0):
     return Game(list(players), seed=seed)
 
 
-def _game_with_records(records):
-    game = _make_game(RandomPlayer(Color.RED), RandomPlayer(Color.BLUE))
-    game.state.action_records = records
-    return game
-
-
 def _move_robber(color, coordinate, robbed_color, stolen):
     return ActionRecord(
         Action(color, ActionType.MOVE_ROBBER, (coordinate, robbed_color)), stolen
     )
 
 
+# ===== Structural separation tests =====
+def test_observation_agent_is_not_a_player():
+    agent = ObservationAgent(Color.RED)
+    assert not isinstance(agent, Player)
+    assert not hasattr(agent, "decide")
+    assert not hasattr(agent, "is_bot")
+
+
+def test_observation_is_pure_data_snapshot():
+    obs = Observation(
+        color=Color.RED,
+        features={"P0_WOOD_IN_HAND": 3},
+        public_history=[],
+        current_prompt=None,
+        current_trade=None,
+        acceptees=(),
+    )
+    assert obs.color == Color.RED
+    assert obs.features["P0_WOOD_IN_HAND"] == 3
+    assert not hasattr(obs, "_game")
+    assert not hasattr(obs, "state")
+
+
 # ===== Sanitizer unit tests (per row of the §3.3 table) =====
-def test_sanitizer_redacts_opponent_buy_dev_card():
+def test_sanitize_redacts_opponent_buy_dev_card():
     record = ActionRecord(
         Action(Color.BLUE, ActionType.BUY_DEVELOPMENT_CARD, "KNIGHT"), "KNIGHT"
     )
-    obs = Observation(_game_with_records([record]), Color.RED)
-    (seen,) = obs.public_history
+    seen = _sanitize_record(record, Color.RED)
     assert seen.action.action_type == ActionType.BUY_DEVELOPMENT_CARD
     assert seen.action.value is None
     assert seen.result is None
 
 
-def test_sanitizer_keeps_own_buy_dev_card():
+def test_sanitize_keeps_own_buy_dev_card():
     record = ActionRecord(
         Action(Color.RED, ActionType.BUY_DEVELOPMENT_CARD, "KNIGHT"), "KNIGHT"
     )
-    obs = Observation(_game_with_records([record]), Color.RED)
-    (seen,) = obs.public_history
+    seen = _sanitize_record(record, Color.RED)
     assert seen.action.value == "KNIGHT"
     assert seen.result == "KNIGHT"
 
 
-def test_sanitizer_spectator_does_not_see_stolen_card():
+def test_sanitize_spectator_does_not_see_stolen_card():
     record = _move_robber(Color.BLUE, (0, 0, 0), Color.ORANGE, "WOOD")
-    obs = Observation(_game_with_records([record]), Color.RED)
-    (seen,) = obs.public_history
+    seen = _sanitize_record(record, Color.RED)
     assert seen.action.value == ((0, 0, 0), Color.ORANGE)
     assert seen.result is None
 
 
-def test_sanitizer_victim_sees_stolen_card():
+def test_sanitize_victim_sees_stolen_card():
     record = _move_robber(Color.BLUE, (0, 0, 0), Color.RED, "WOOD")
-    obs = Observation(_game_with_records([record]), Color.RED)
-    (seen,) = obs.public_history
+    seen = _sanitize_record(record, Color.RED)
     assert seen.action.value == ((0, 0, 0), Color.RED)
     assert seen.result == "WOOD"
 
 
-def test_sanitizer_keeps_own_move_robber():
+def test_sanitize_keeps_own_move_robber():
     record = _move_robber(Color.RED, (0, 0, 0), Color.BLUE, "WOOD")
-    obs = Observation(_game_with_records([record]), Color.RED)
-    (seen,) = obs.public_history
+    seen = _sanitize_record(record, Color.RED)
     assert seen.action.value == ((0, 0, 0), Color.BLUE)
     assert seen.result == "WOOD"
 
 
-def test_sanitizer_discards_are_public():
+def test_sanitize_discards_are_public():
     record = ActionRecord(
         Action(Color.BLUE, ActionType.DISCARD_RESOURCE, "WOOD"), "WOOD"
     )
-    obs = Observation(_game_with_records([record]), Color.RED)
-    (seen,) = obs.public_history
+    seen = _sanitize_record(record, Color.RED)
     assert seen.action.value == "WOOD"
     assert seen.result == "WOOD"
 
 
-def test_sanitizer_passes_through_public_actions():
+def test_sanitize_passes_through_public_actions():
     record = ActionRecord(Action(Color.BLUE, ActionType.ROLL, None), (3, 4))
-    obs = Observation(_game_with_records([record]), Color.RED)
-    (seen,) = obs.public_history
-    assert seen == record
+    assert _sanitize_record(record, Color.RED) == record
 
 
 # ===== Fairness invariants over full games =====
 @pytest.mark.parametrize("seed", range(5))
 def test_no_opponent_private_info_leaks(seed):
-    recorder = RecorderPlayer(Color.RED)
+    recorder = RecorderAgent(Color.RED)
     game = _make_game(
-        recorder,
+        PerspectivePlayer(recorder),
         RandomPlayer(Color.BLUE),
         RandomPlayer(Color.ORANGE),
         seed=seed,
@@ -146,6 +161,10 @@ def test_no_opponent_private_info_leaks(seed):
     assert len(recorder.observations) > 0
 
     for obs in recorder.observations:
+        assert isinstance(obs, Observation)
+        assert not hasattr(obs, "_game")
+        assert not hasattr(obs, "state")
+
         violations = []
         scan(obs.features, "features", violations)
         assert not violations, violations
@@ -166,9 +185,9 @@ def test_no_opponent_private_info_leaks(seed):
 
 @pytest.mark.parametrize("seed", range(3))
 def test_public_hand_counts_reachable(seed):
-    recorder = RecorderPlayer(Color.RED)
+    recorder = RecorderAgent(Color.RED)
     game = _make_game(
-        recorder,
+        PerspectivePlayer(recorder),
         RandomPlayer(Color.BLUE),
         RandomPlayer(Color.ORANGE),
         seed=seed,
@@ -185,9 +204,9 @@ def test_public_hand_counts_reachable(seed):
 
 # ===== Seam tests =====
 def test_perspective_player_plays_game_to_completion():
-    recorder = RecorderPlayer(Color.RED)
+    recorder = RecorderAgent(Color.RED)
     game = _make_game(
-        recorder,
+        PerspectivePlayer(recorder),
         RandomPlayer(Color.BLUE),
         RandomPlayer(Color.ORANGE),
         seed=42,
@@ -197,38 +216,46 @@ def test_perspective_player_plays_game_to_completion():
     assert len(recorder.observations) > 0
 
 
-def test_decide_fn_seam():
-    players = [
-        RecorderPlayer(Color.RED),
-        RecorderPlayer(Color.BLUE),
-        RecorderPlayer(Color.ORANGE),
+def test_decide_fn_seam_drives_bare_agents():
+    agents = [
+        RecorderAgent(Color.RED),
+        RecorderAgent(Color.BLUE),
+        RecorderAgent(Color.ORANGE),
     ]
-    game = Game(players, seed=7)
+    game = Game(agents, seed=7)
 
     def decide_fn(player, g, actions):
-        return player.decide_observation(Observation(g, player.color), actions)
+        return player.decide_observation(
+            Observation(
+                color=player.color,
+                features=create_sample(g, player.color),
+                public_history=_sanitize_history(g, player.color),
+                current_prompt=g.state.current_prompt,
+                current_trade=g.state.current_trade,
+                acceptees=g.state.acceptees,
+            ),
+            actions,
+        )
 
     game.play(decide_fn=decide_fn)
-    assert all(len(p.observations) > 0 for p in players)
+    assert all(len(agent.observations) > 0 for agent in agents)
 
 
-def test_reset_state_via_inheritance():
-    player = PerspectivePlayer(Color.RED)
-    assert "reset_state" not in PerspectivePlayer.__dict__  # inherited, not redefined
-    player.reset_state()  # must not raise
+def test_reset_state_hook_on_agent():
+    agent = ObservationAgent(Color.RED)
+    agent.reset_state()  # must not raise
 
 
-def test_reset_state_between_games():
-    recorder = RecorderPlayer(Color.RED)
-    for _ in range(2):
-        game = _make_game(
-            recorder,
-            RandomPlayer(Color.BLUE),
-            RandomPlayer(Color.ORANGE),
-            seed=11,
-        )
-        game.play()
-        assert recorder.calls_since_reset > 0
-        recorder.reset_state()
-        assert recorder.calls_since_reset == 0
-    assert len(recorder.observations) > 0
+def test_reset_state_delegates_to_agent():
+    recorder = RecorderAgent(Color.RED)
+    player = PerspectivePlayer(recorder)
+    game = _make_game(
+        player,
+        RandomPlayer(Color.BLUE),
+        RandomPlayer(Color.ORANGE),
+        seed=11,
+    )
+    game.play()
+    assert recorder.calls_since_reset > 0
+    player.reset_state()
+    assert recorder.calls_since_reset == 0

--- a/tests/test_observation.py
+++ b/tests/test_observation.py
@@ -1,0 +1,234 @@
+import re
+
+import pytest
+
+from catanatron.game import Game
+from catanatron.models.enums import (
+    DEVELOPMENT_CARDS,
+    RESOURCES,
+    Action,
+    ActionRecord,
+    ActionType,
+)
+from catanatron.models.observation import Observation
+from catanatron.models.perspective_player import PerspectivePlayer
+from catanatron.models.player import Color, RandomPlayer
+
+
+class RecorderPlayer(PerspectivePlayer):
+    """Trivial fair bot that records every Observation it receives."""
+
+    def __init__(self, color):
+        super().__init__(color, is_bot=True)
+        self.observations = []
+        self.calls_since_reset = 0
+
+    def decide_observation(self, observation, playable_actions):
+        self.observations.append(observation)
+        self.calls_since_reset += 1
+        return playable_actions[0]
+
+    def reset_state(self):
+        super().reset_state()
+        self.calls_since_reset = 0
+
+
+HIDDEN_PATTERNS = [
+    re.compile(rf"^P[1-9]_{resource}_IN_HAND$") for resource in RESOURCES
+] + [
+    re.compile(rf"^P[1-9]_{card}_IN_HAND$") for card in DEVELOPMENT_CARDS
+] + [
+    re.compile(r"^P[1-9]_ACTUAL_VICTORY_POINTS$"),
+]
+
+
+def scan(value, path, violations):
+    if isinstance(value, dict):
+        for k, v in value.items():
+            if any(p.match(str(k)) for p in HIDDEN_PATTERNS):
+                violations.append(f"{path}.{k}")
+            scan(v, f"{path}.{k}", violations)
+    elif isinstance(value, (list, tuple)):
+        for i, v in enumerate(value):
+            scan(v, f"{path}[{i}]", violations)
+
+
+def _make_game(*players, seed=0):
+    return Game(list(players), seed=seed)
+
+
+def _game_with_records(records):
+    game = _make_game(RandomPlayer(Color.RED), RandomPlayer(Color.BLUE))
+    game.state.action_records = records
+    return game
+
+
+def _move_robber(color, coordinate, robbed_color, stolen):
+    return ActionRecord(
+        Action(color, ActionType.MOVE_ROBBER, (coordinate, robbed_color)), stolen
+    )
+
+
+# ===== Sanitizer unit tests (per row of the §3.3 table) =====
+def test_sanitizer_redacts_opponent_buy_dev_card():
+    record = ActionRecord(
+        Action(Color.BLUE, ActionType.BUY_DEVELOPMENT_CARD, "KNIGHT"), "KNIGHT"
+    )
+    obs = Observation(_game_with_records([record]), Color.RED)
+    (seen,) = obs.public_history
+    assert seen.action.action_type == ActionType.BUY_DEVELOPMENT_CARD
+    assert seen.action.value is None
+    assert seen.result is None
+
+
+def test_sanitizer_keeps_own_buy_dev_card():
+    record = ActionRecord(
+        Action(Color.RED, ActionType.BUY_DEVELOPMENT_CARD, "KNIGHT"), "KNIGHT"
+    )
+    obs = Observation(_game_with_records([record]), Color.RED)
+    (seen,) = obs.public_history
+    assert seen.action.value == "KNIGHT"
+    assert seen.result == "KNIGHT"
+
+
+def test_sanitizer_spectator_does_not_see_stolen_card():
+    record = _move_robber(Color.BLUE, (0, 0, 0), Color.ORANGE, "WOOD")
+    obs = Observation(_game_with_records([record]), Color.RED)
+    (seen,) = obs.public_history
+    assert seen.action.value == ((0, 0, 0), Color.ORANGE)
+    assert seen.result is None
+
+
+def test_sanitizer_victim_sees_stolen_card():
+    record = _move_robber(Color.BLUE, (0, 0, 0), Color.RED, "WOOD")
+    obs = Observation(_game_with_records([record]), Color.RED)
+    (seen,) = obs.public_history
+    assert seen.action.value == ((0, 0, 0), Color.RED)
+    assert seen.result == "WOOD"
+
+
+def test_sanitizer_keeps_own_move_robber():
+    record = _move_robber(Color.RED, (0, 0, 0), Color.BLUE, "WOOD")
+    obs = Observation(_game_with_records([record]), Color.RED)
+    (seen,) = obs.public_history
+    assert seen.action.value == ((0, 0, 0), Color.BLUE)
+    assert seen.result == "WOOD"
+
+
+def test_sanitizer_discards_are_public():
+    record = ActionRecord(
+        Action(Color.BLUE, ActionType.DISCARD_RESOURCE, "WOOD"), "WOOD"
+    )
+    obs = Observation(_game_with_records([record]), Color.RED)
+    (seen,) = obs.public_history
+    assert seen.action.value == "WOOD"
+    assert seen.result == "WOOD"
+
+
+def test_sanitizer_passes_through_public_actions():
+    record = ActionRecord(Action(Color.BLUE, ActionType.ROLL, None), (3, 4))
+    obs = Observation(_game_with_records([record]), Color.RED)
+    (seen,) = obs.public_history
+    assert seen == record
+
+
+# ===== Fairness invariants over full games =====
+@pytest.mark.parametrize("seed", range(5))
+def test_no_opponent_private_info_leaks(seed):
+    recorder = RecorderPlayer(Color.RED)
+    game = _make_game(
+        recorder,
+        RandomPlayer(Color.BLUE),
+        RandomPlayer(Color.ORANGE),
+        seed=seed,
+    )
+    game.play()
+    assert len(recorder.observations) > 0
+
+    for obs in recorder.observations:
+        violations = []
+        scan(obs.features, "features", violations)
+        assert not violations, violations
+
+        for record in obs.public_history:
+            action = record.action
+            if action.color == obs.color:
+                continue  # own records retain full detail
+            if action.action_type == ActionType.BUY_DEVELOPMENT_CARD:
+                assert action.value is None
+                assert record.result is None
+            elif action.action_type == ActionType.MOVE_ROBBER:
+                if action.value is not None and action.value[1] == obs.color:
+                    assert record.result is not None  # victim knows the card
+                else:
+                    assert record.result is None
+
+
+@pytest.mark.parametrize("seed", range(3))
+def test_public_hand_counts_reachable(seed):
+    recorder = RecorderPlayer(Color.RED)
+    game = _make_game(
+        recorder,
+        RandomPlayer(Color.BLUE),
+        RandomPlayer(Color.ORANGE),
+        seed=seed,
+    )
+    game.play()
+
+    for obs in recorder.observations:
+        features = obs.features
+        for opponent_index in range(1, len(game.state.colors)):
+            assert f"P{opponent_index}_NUM_RESOURCES_IN_HAND" in features
+            assert f"P{opponent_index}_NUM_DEVS_IN_HAND" in features
+            assert f"P{opponent_index}_PUBLIC_VPS" in features
+
+
+# ===== Seam tests =====
+def test_perspective_player_plays_game_to_completion():
+    recorder = RecorderPlayer(Color.RED)
+    game = _make_game(
+        recorder,
+        RandomPlayer(Color.BLUE),
+        RandomPlayer(Color.ORANGE),
+        seed=42,
+    )
+    winner = game.play()
+    assert winner is None or winner in game.state.colors
+    assert len(recorder.observations) > 0
+
+
+def test_decide_fn_seam():
+    players = [
+        RecorderPlayer(Color.RED),
+        RecorderPlayer(Color.BLUE),
+        RecorderPlayer(Color.ORANGE),
+    ]
+    game = Game(players, seed=7)
+
+    def decide_fn(player, g, actions):
+        return player.decide_observation(Observation(g, player.color), actions)
+
+    game.play(decide_fn=decide_fn)
+    assert all(len(p.observations) > 0 for p in players)
+
+
+def test_reset_state_via_inheritance():
+    player = PerspectivePlayer(Color.RED)
+    assert "reset_state" not in PerspectivePlayer.__dict__  # inherited, not redefined
+    player.reset_state()  # must not raise
+
+
+def test_reset_state_between_games():
+    recorder = RecorderPlayer(Color.RED)
+    for _ in range(2):
+        game = _make_game(
+            recorder,
+            RandomPlayer(Color.BLUE),
+            RandomPlayer(Color.ORANGE),
+            seed=11,
+        )
+        game.play()
+        assert recorder.calls_since_reset > 0
+        recorder.reset_state()
+        assert recorder.calls_since_reset == 0
+    assert len(recorder.observations) > 0

--- a/tests/test_observation.py
+++ b/tests/test_observation.py
@@ -12,18 +12,25 @@ from catanatron.models.enums import (
     ActionRecord,
     ActionType,
 )
+from catanatron.models.inventory import Inventory
 from catanatron.models.observation import Observation
 from catanatron.models.observation_agent import ObservationAgent
 from catanatron.models.perspective_player import (
     PerspectivePlayer,
     _build_inventory,
+    _build_pending_trades,
     _build_public_state,
     _sanitize_history,
     _sanitize_record,
 )
-from catanatron.models.inventory import Inventory
 from catanatron.models.player import Color, Player, RandomPlayer
-from catanatron.models.public_state import PublicBoard, PublicPlayer, PublicState
+from catanatron.models.public_state import (
+    PublicBoard,
+    PublicMap,
+    PublicPlayer,
+    PublicState,
+)
+from catanatron.models.trade import PendingTrades, TradeOffer
 
 
 class RecorderAgent(ObservationAgent):
@@ -88,15 +95,15 @@ def test_observation_is_pure_data_snapshot():
     obs = Observation(
         color=Color.RED,
         features={"P0_WOOD_IN_HAND": 3},
-        public_history=[],
+        public_history=(),
         current_prompt=None,
-        current_trade=None,
-        acceptees=(),
     )
     assert obs.color == Color.RED
     assert obs.features["P0_WOOD_IN_HAND"] == 3
     assert obs.public_state is None
     assert obs.inventory is None
+    assert obs.pending_trades == PendingTrades()
+    assert obs.own is None  # no public_state, so no own entry
     assert not hasattr(obs, "_game")
     assert not hasattr(obs, "state")
 
@@ -156,6 +163,51 @@ def test_sanitize_passes_through_public_actions():
     assert _sanitize_record(record, Color.RED) == record
 
 
+def test_observation_own_returns_observer_public_player():
+    observations, _ = _play_recorded_game(seed=15)
+    obs = observations[0]
+    assert isinstance(obs.own, PublicPlayer)
+    assert obs.own == obs.public_state.players[Color.RED]
+    assert obs.own.public_vps >= 0
+
+
+# ===== pending trades (typed trade objects) =====
+def test_pending_trades_builds_typed_offer():
+    from catanatron.apply_action import apply_action, apply_accept_trade
+
+    game = _make_game(
+        RandomPlayer(Color.RED),
+        RandomPlayer(Color.BLUE),
+        RandomPlayer(Color.ORANGE),
+        seed=13,
+    )
+
+    assert _build_pending_trades(game) == PendingTrades()
+
+    # offer 2 wood, ask 1 wheat (10-tuple: offered x5 + asking x5)
+    offer_value = (2, 0, 0, 0, 0, 0, 0, 0, 1, 0)
+    apply_action(game.state, Action(Color.RED, ActionType.OFFER_TRADE, offer_value))
+
+    offers = _build_pending_trades(game)
+    assert isinstance(offers, PendingTrades)
+    assert len(offers) == 1
+    offer = offers[0]
+    assert isinstance(offer, TradeOffer)
+    assert offers.is_active
+    assert offers.single is offer
+    assert offer.offerer == Color.RED
+    assert offer.offered == {"WOOD": 2, "BRICK": 0, "SHEEP": 0, "WHEAT": 0, "ORE": 0}
+    assert offer.asking == {"WOOD": 0, "BRICK": 0, "SHEEP": 0, "WHEAT": 1, "ORE": 0}
+    assert offer.acceptees == {Color.RED: False, Color.BLUE: False, Color.ORANGE: False}
+
+    apply_action(
+        game.state,
+        Action(Color.BLUE, ActionType.ACCEPT_TRADE, game.state.current_trade),
+    )
+    offer = _build_pending_trades(game).single
+    assert offer.acceptees == {Color.RED: False, Color.BLUE: True, Color.ORANGE: False}
+
+
 # ===== public_state (structured public surface) =====
 def _play_recorded_game(seed=0):
     """Plays a game through the decide_fn seam, recording for the RED agent
@@ -178,8 +230,7 @@ def _play_recorded_game(seed=0):
             features=create_sample(g, player.color),
             public_history=_sanitize_history(g, player.color),
             current_prompt=g.state.current_prompt,
-            current_trade=g.state.current_trade,
-            acceptees=g.state.acceptees,
+            pending_trades=_build_pending_trades(g),
             public_state=_build_public_state(g),
             inventory=_build_inventory(g, player.color),
         )
@@ -216,6 +267,64 @@ def test_public_state_matches_engine_board():
             edge: color for edge, color in snap["roads"].items() if edge[0] < edge[1]
         }
         assert public_board.roads == expected_roads
+
+
+def test_public_state_map_matches_engine_map():
+    game = _make_game(
+        PerspectivePlayer(RecorderAgent(Color.RED)),
+        RandomPlayer(Color.BLUE),
+        RandomPlayer(Color.ORANGE),
+        seed=10,
+    )
+    state = _build_public_state(game)
+    public_map = state.board.map
+    engine_map = game.state.board.map
+    assert isinstance(public_map, PublicMap)
+
+    expected_tiles = {
+        t.id: (t.resource, t.number) for t in engine_map.tiles_by_id.values()
+    }
+    from catanatron.models.map import PORT_DIRECTION_TO_NODEREFS
+
+    def _trading_nodes(port):
+        a_ref, b_ref = PORT_DIRECTION_TO_NODEREFS[port.direction]
+        return (port.nodes[a_ref], port.nodes[b_ref])
+
+    expected_ports = {
+        p.id: (p.resource, _trading_nodes(p)) for p in engine_map.ports_by_id.values()
+    }
+    expected_adjacency = {
+        node_id: tuple(t.id for t in tiles_list)
+        for node_id, tiles_list in engine_map.adjacent_tiles.items()
+    }
+    assert public_map.tiles == expected_tiles
+    assert public_map.ports == expected_ports
+    assert public_map.adjacent_tiles == expected_adjacency
+    assert public_map.land_nodes == frozenset(engine_map.land_nodes)
+
+    for tile_id, (resource, number) in public_map.tiles.items():
+        assert 0 <= tile_id < len(engine_map.tiles_by_id)
+        assert (resource is None) == (number is None)  # only deserts have no roll
+
+    # Probabilities are not stored: they are inferable from tile rolls + adjacency.
+    from catanatron.models.map import number_probability
+
+    inferred = {}
+    for node_id, tile_ids in public_map.adjacent_tiles.items():
+        production = {}
+        for tile_id in tile_ids:
+            resource, number = public_map.tiles[tile_id]
+            if resource is None:
+                continue
+            production[resource] = production.get(resource, 0.0) + number_probability(
+                number
+            )
+        inferred[node_id] = production
+    expected_production = {
+        node_id: dict(counter)
+        for node_id, counter in engine_map.node_production.items()
+    }
+    assert inferred == expected_production
 
 
 def test_public_state_per_player_public_counts():
@@ -293,6 +402,7 @@ def test_build_inventory_matches_engine_hand():
             obs.inventory.has_played_development_card
             == player_state[f"{key}_HAS_PLAYED_DEVELOPMENT_CARD_IN_TURN"]
         )
+        assert obs.inventory.actual_vps == player_state[f"{key}_ACTUAL_VICTORY_POINTS"]
 
 
 def test_inventory_is_only_for_observer_color():
@@ -315,8 +425,7 @@ def test_inventory_is_only_for_observer_color():
                 features=create_sample(g, player.color),
                 public_history=_sanitize_history(g, player.color),
                 current_prompt=g.state.current_prompt,
-                current_trade=g.state.current_trade,
-                acceptees=g.state.acceptees,
+                pending_trades=_build_pending_trades(g),
                 public_state=_build_public_state(g),
                 inventory=_build_inventory(g, player.color),
             )
@@ -345,6 +454,7 @@ def test_inventory_construction_is_standalone():
         inv.has_played_development_card
         == player_state[f"{key}_HAS_PLAYED_DEVELOPMENT_CARD_IN_TURN"]
     )
+    assert inv.actual_vps == player_state[f"{key}_ACTUAL_VICTORY_POINTS"]
 
 
 # ===== Fairness invariants over full games =====
@@ -367,6 +477,10 @@ def test_no_opponent_private_info_leaks(seed):
 
         violations = []
         scan(obs.features, "features", violations)
+        assert not violations, violations
+
+        violations = []
+        scan(obs.pending_trades, "pending_trades", violations)
         assert not violations, violations
 
         for record in obs.public_history:
@@ -431,8 +545,7 @@ def test_decide_fn_seam_drives_bare_agents():
                 features=create_sample(g, player.color),
                 public_history=_sanitize_history(g, player.color),
                 current_prompt=g.state.current_prompt,
-                current_trade=g.state.current_trade,
-                acceptees=g.state.acceptees,
+                pending_trades=_build_pending_trades(g),
                 public_state=_build_public_state(g),
             ),
             actions,

--- a/tests/test_observation.py
+++ b/tests/test_observation.py
@@ -1,3 +1,4 @@
+import dataclasses
 import re
 
 import pytest
@@ -15,11 +16,14 @@ from catanatron.models.observation import Observation
 from catanatron.models.observation_agent import ObservationAgent
 from catanatron.models.perspective_player import (
     PerspectivePlayer,
+    _build_inventory,
     _build_public_state,
     _sanitize_history,
     _sanitize_record,
 )
+from catanatron.models.inventory import Inventory
 from catanatron.models.player import Color, Player, RandomPlayer
+from catanatron.models.public_state import PublicBoard, PublicPlayer, PublicState
 
 
 class RecorderAgent(ObservationAgent):
@@ -50,6 +54,8 @@ HIDDEN_PATTERNS = (
 
 
 def scan(value, path, violations):
+    if dataclasses.is_dataclass(value):
+        value = dataclasses.asdict(value)
     if isinstance(value, dict):
         for k, v in value.items():
             if any(p.match(str(k)) for p in HIDDEN_PATTERNS):
@@ -89,7 +95,8 @@ def test_observation_is_pure_data_snapshot():
     )
     assert obs.color == Color.RED
     assert obs.features["P0_WOOD_IN_HAND"] == 3
-    assert obs.public_state == {}
+    assert obs.public_state is None
+    assert obs.inventory is None
     assert not hasattr(obs, "_game")
     assert not hasattr(obs, "state")
 
@@ -174,6 +181,7 @@ def _play_recorded_game(seed=0):
             current_trade=g.state.current_trade,
             acceptees=g.state.acceptees,
             public_state=_build_public_state(g),
+            inventory=_build_inventory(g, player.color),
         )
         observations.append(observation)
         snapshots.append(
@@ -197,45 +205,51 @@ def test_public_state_matches_engine_board():
     observations, snapshots = _play_recorded_game(seed=2)
     assert observations
     for obs, snap in zip(observations, snapshots):
-        public_board = obs.public_state["board"]
-        assert public_board["robber_coordinate"] == snap["robber_coordinate"]
-        assert public_board["longest_road_color"] == snap["road_color"]
-        assert public_board["longest_road_length"] == snap["road_length"]
-        assert public_board["buildings"] == snap["buildings"]
+        assert isinstance(obs.public_state, PublicState)
+        public_board = obs.public_state.board
+        assert isinstance(public_board, PublicBoard)
+        assert public_board.robber_coordinate == snap["robber_coordinate"]
+        assert public_board.longest_road_color == snap["road_color"]
+        assert public_board.longest_road_length == snap["road_length"]
+        assert public_board.buildings == snap["buildings"]
         expected_roads = {
             edge: color for edge, color in snap["roads"].items() if edge[0] < edge[1]
         }
-        assert public_board["roads"] == expected_roads
+        assert public_board.roads == expected_roads
 
 
 def test_public_state_per_player_public_counts():
     observations, snapshots = _play_recorded_game(seed=3)
     for obs, snap in zip(observations, snapshots):
-        players = obs.public_state["players"]
+        players = obs.public_state.players
         assert set(players.keys()) == set(snap["colors"])
         player_state = snap["player_state"]
         for color, public in players.items():
+            assert isinstance(public, PublicPlayer)
             key = f"P{snap['colors'].index(color)}"
-            assert public["public_vps"] == player_state[f"{key}_VICTORY_POINTS"]
-            assert public["has_army"] == player_state[f"{key}_HAS_ARMY"]
-            assert public["has_road"] == player_state[f"{key}_HAS_ROAD"]
+            assert public.public_vps == player_state[f"{key}_VICTORY_POINTS"]
+            assert public.has_army == player_state[f"{key}_HAS_ARMY"]
+            assert public.has_road == player_state[f"{key}_HAS_ROAD"]
             assert (
-                public["longest_road_length"]
-                == player_state[f"{key}_LONGEST_ROAD_LENGTH"]
+                public.longest_road_length == player_state[f"{key}_LONGEST_ROAD_LENGTH"]
             )
-            assert public["roads_left"] == player_state[f"{key}_ROADS_AVAILABLE"]
+            assert public.roads_left == player_state[f"{key}_ROADS_AVAILABLE"]
             assert (
-                public["settlements_left"]
-                == player_state[f"{key}_SETTLEMENTS_AVAILABLE"]
+                public.settlements_left == player_state[f"{key}_SETTLEMENTS_AVAILABLE"]
             )
-            assert public["cities_left"] == player_state[f"{key}_CITIES_AVAILABLE"]
-            assert public["has_rolled"] == player_state[f"{key}_HAS_ROLLED"]
-            assert public["hand_resource_count"] == sum(
+            assert public.cities_left == player_state[f"{key}_CITIES_AVAILABLE"]
+            assert public.has_rolled == player_state[f"{key}_HAS_ROLLED"]
+            assert public.hand_resource_count == sum(
                 player_state[f"{key}_{r}_IN_HAND"] for r in RESOURCES
             )
-            assert public["hand_dev_count"] == sum(
+            assert public.hand_dev_count == sum(
                 player_state[f"{key}_{d}_IN_HAND"] for d in DEVELOPMENT_CARDS
             )
+            for card in DEVELOPMENT_CARDS:
+                assert (
+                    getattr(public, f"played_{card.lower()}")
+                    == player_state[f"{key}_PLAYED_{card}"]
+                )
 
 
 def test_public_state_leaks_no_opponent_private_info():
@@ -244,17 +258,93 @@ def test_public_state_leaks_no_opponent_private_info():
         violations = []
         scan(obs.public_state, "public_state", violations)
         assert not violations, violations
-        for public in obs.public_state["players"].values():
-            assert "actual_vps" not in public
-            assert not any(key.endswith("_IN_HAND") for key in public)
+        for public in obs.public_state.players.values():
+            assert not hasattr(public, "actual_vps")
+            assert not any(field.endswith("_IN_HAND") for field in vars(public))
 
 
 def test_build_public_state_is_standalone():
     game = _make_game(RandomPlayer(Color.RED), seed=5)
     state = _build_public_state(game)
-    assert state["board"]["buildings"] == {}
-    assert state["board"]["robber_coordinate"] == game.state.board.robber_coordinate
-    assert set(state["players"].keys()) == set(game.state.colors)
+    assert isinstance(state, PublicState)
+    assert state.board.buildings == {}
+    assert state.board.robber_coordinate == game.state.board.robber_coordinate
+    assert set(state.players.keys()) == set(game.state.colors)
+
+
+# ===== inventory (observer's private hand) =====
+def test_build_inventory_matches_engine_hand():
+    observations, snapshots = _play_recorded_game(seed=6)
+    for obs, snap in zip(observations, snapshots):
+        assert isinstance(obs.inventory, Inventory)
+        key = f"P{snap['colors'].index(obs.color)}"
+        player_state = snap["player_state"]
+        for resource in RESOURCES:
+            assert (
+                getattr(obs.inventory, resource.lower())
+                == player_state[f"{key}_{resource}_IN_HAND"]
+            )
+        for card in DEVELOPMENT_CARDS:
+            assert (
+                getattr(obs.inventory, card.lower())
+                == player_state[f"{key}_{card}_IN_HAND"]
+            )
+        assert (
+            obs.inventory.has_played_development_card
+            == player_state[f"{key}_HAS_PLAYED_DEVELOPMENT_CARD_IN_TURN"]
+        )
+
+
+def test_inventory_is_only_for_observer_color():
+    recorder = RecorderAgent(Color.RED)
+    game = _make_game(
+        recorder,
+        RandomPlayer(Color.BLUE),
+        RandomPlayer(Color.ORANGE),
+        seed=8,
+    )
+    observations = []
+    player_states = []
+
+    def decide_fn(player, g, actions):
+        if player is not recorder:
+            return player.decide(g, actions)
+        observations.append(
+            Observation(
+                color=player.color,
+                features=create_sample(g, player.color),
+                public_history=_sanitize_history(g, player.color),
+                current_prompt=g.state.current_prompt,
+                current_trade=g.state.current_trade,
+                acceptees=g.state.acceptees,
+                public_state=_build_public_state(g),
+                inventory=_build_inventory(g, player.color),
+            )
+        )
+        player_states.append(dict(g.state.player_state))
+        return player.decide_observation(observations[-1], actions)
+
+    game.play(decide_fn=decide_fn)
+    assert observations
+    key = f"P{game.state.colors.index(Color.RED)}"
+    for obs, player_state in zip(observations, player_states):
+        assert obs.color == Color.RED
+        assert obs.inventory is not None
+        assert obs.inventory.wood == player_state[f"{key}_WOOD_IN_HAND"]
+
+
+def test_inventory_construction_is_standalone():
+    game = _make_game(RandomPlayer(Color.RED), seed=9)
+    inv = _build_inventory(game, Color.RED)
+    assert isinstance(inv, Inventory)
+    key = f"P{game.state.colors.index(Color.RED)}"
+    player_state = game.state.player_state
+    assert inv.wood == player_state[f"{key}_WOOD_IN_HAND"]
+    assert inv.knight == player_state[f"{key}_KNIGHT_IN_HAND"]
+    assert (
+        inv.has_played_development_card
+        == player_state[f"{key}_HAS_PLAYED_DEVELOPMENT_CARD_IN_TURN"]
+    )
 
 
 # ===== Fairness invariants over full games =====

--- a/tests/test_observation.py
+++ b/tests/test_observation.py
@@ -15,6 +15,7 @@ from catanatron.models.observation import Observation
 from catanatron.models.observation_agent import ObservationAgent
 from catanatron.models.perspective_player import (
     PerspectivePlayer,
+    _build_public_state,
     _sanitize_history,
     _sanitize_record,
 )
@@ -39,13 +40,13 @@ class RecorderAgent(ObservationAgent):
         self.calls_since_reset = 0
 
 
-HIDDEN_PATTERNS = [
-    re.compile(rf"^P[1-9]_{resource}_IN_HAND$") for resource in RESOURCES
-] + [
-    re.compile(rf"^P[1-9]_{card}_IN_HAND$") for card in DEVELOPMENT_CARDS
-] + [
-    re.compile(r"^P[1-9]_ACTUAL_VICTORY_POINTS$"),
-]
+HIDDEN_PATTERNS = (
+    [re.compile(rf"^P[1-9]_{resource}_IN_HAND$") for resource in RESOURCES]
+    + [re.compile(rf"^P[1-9]_{card}_IN_HAND$") for card in DEVELOPMENT_CARDS]
+    + [
+        re.compile(r"^P[1-9]_ACTUAL_VICTORY_POINTS$"),
+    ]
+)
 
 
 def scan(value, path, violations):
@@ -88,6 +89,7 @@ def test_observation_is_pure_data_snapshot():
     )
     assert obs.color == Color.RED
     assert obs.features["P0_WOOD_IN_HAND"] == 3
+    assert obs.public_state == {}
     assert not hasattr(obs, "_game")
     assert not hasattr(obs, "state")
 
@@ -145,6 +147,114 @@ def test_sanitize_discards_are_public():
 def test_sanitize_passes_through_public_actions():
     record = ActionRecord(Action(Color.BLUE, ActionType.ROLL, None), (3, 4))
     assert _sanitize_record(record, Color.RED) == record
+
+
+# ===== public_state (structured public surface) =====
+def _play_recorded_game(seed=0):
+    """Plays a game through the decide_fn seam, recording for the RED agent
+    each Observation plus a snapshot of the engine state it was built from."""
+    recorder = RecorderAgent(Color.RED)
+    game = _make_game(
+        recorder,
+        RandomPlayer(Color.BLUE),
+        RandomPlayer(Color.ORANGE),
+        seed=seed,
+    )
+    observations = []
+    snapshots = []
+
+    def decide_fn(player, g, actions):
+        if player is not recorder:
+            return player.decide(g, actions)
+        observation = Observation(
+            color=player.color,
+            features=create_sample(g, player.color),
+            public_history=_sanitize_history(g, player.color),
+            current_prompt=g.state.current_prompt,
+            current_trade=g.state.current_trade,
+            acceptees=g.state.acceptees,
+            public_state=_build_public_state(g),
+        )
+        observations.append(observation)
+        snapshots.append(
+            {
+                "colors": tuple(g.state.colors),
+                "buildings": dict(g.state.board.buildings),
+                "roads": dict(g.state.board.roads),
+                "robber_coordinate": g.state.board.robber_coordinate,
+                "road_color": g.state.board.road_color,
+                "road_length": g.state.board.road_length,
+                "player_state": dict(g.state.player_state),
+            }
+        )
+        return player.decide_observation(observation, actions)
+
+    game.play(decide_fn=decide_fn)
+    return observations, snapshots
+
+
+def test_public_state_matches_engine_board():
+    observations, snapshots = _play_recorded_game(seed=2)
+    assert observations
+    for obs, snap in zip(observations, snapshots):
+        public_board = obs.public_state["board"]
+        assert public_board["robber_coordinate"] == snap["robber_coordinate"]
+        assert public_board["longest_road_color"] == snap["road_color"]
+        assert public_board["longest_road_length"] == snap["road_length"]
+        assert public_board["buildings"] == snap["buildings"]
+        expected_roads = {
+            edge: color for edge, color in snap["roads"].items() if edge[0] < edge[1]
+        }
+        assert public_board["roads"] == expected_roads
+
+
+def test_public_state_per_player_public_counts():
+    observations, snapshots = _play_recorded_game(seed=3)
+    for obs, snap in zip(observations, snapshots):
+        players = obs.public_state["players"]
+        assert set(players.keys()) == set(snap["colors"])
+        player_state = snap["player_state"]
+        for color, public in players.items():
+            key = f"P{snap['colors'].index(color)}"
+            assert public["public_vps"] == player_state[f"{key}_VICTORY_POINTS"]
+            assert public["has_army"] == player_state[f"{key}_HAS_ARMY"]
+            assert public["has_road"] == player_state[f"{key}_HAS_ROAD"]
+            assert (
+                public["longest_road_length"]
+                == player_state[f"{key}_LONGEST_ROAD_LENGTH"]
+            )
+            assert public["roads_left"] == player_state[f"{key}_ROADS_AVAILABLE"]
+            assert (
+                public["settlements_left"]
+                == player_state[f"{key}_SETTLEMENTS_AVAILABLE"]
+            )
+            assert public["cities_left"] == player_state[f"{key}_CITIES_AVAILABLE"]
+            assert public["has_rolled"] == player_state[f"{key}_HAS_ROLLED"]
+            assert public["hand_resource_count"] == sum(
+                player_state[f"{key}_{r}_IN_HAND"] for r in RESOURCES
+            )
+            assert public["hand_dev_count"] == sum(
+                player_state[f"{key}_{d}_IN_HAND"] for d in DEVELOPMENT_CARDS
+            )
+
+
+def test_public_state_leaks_no_opponent_private_info():
+    observations, _ = _play_recorded_game(seed=4)
+    for obs in observations:
+        violations = []
+        scan(obs.public_state, "public_state", violations)
+        assert not violations, violations
+        for public in obs.public_state["players"].values():
+            assert "actual_vps" not in public
+            assert not any(key.endswith("_IN_HAND") for key in public)
+
+
+def test_build_public_state_is_standalone():
+    game = _make_game(RandomPlayer(Color.RED), seed=5)
+    state = _build_public_state(game)
+    assert state["board"]["buildings"] == {}
+    assert state["board"]["robber_coordinate"] == game.state.board.robber_coordinate
+    assert set(state["players"].keys()) == set(game.state.colors)
 
 
 # ===== Fairness invariants over full games =====
@@ -233,6 +343,7 @@ def test_decide_fn_seam_drives_bare_agents():
                 current_prompt=g.state.current_prompt,
                 current_trade=g.state.current_trade,
                 acceptees=g.state.acceptees,
+                public_state=_build_public_state(g),
             ),
             actions,
         )


### PR DESCRIPTION
## Summary

Adds an opt-in, backward-compatible layer for playing against humans *fairly*: bots can no longer read the full-truth `Game`. Ships three new classes — `ObservationAgent`, `PerspectivePlayer`, and `Observation` — plus 21 tests in `tests/test_observation.py`. The engine (`Player`, `Game`, `State`, `apply_action`, `json.py`, CLI, gym) is untouched.

## Problem

`Player.decide(game, playable_actions)` hands every bot the full-truth `Game`. That is correct for self-play, training, and offline analysis — but it makes bots **cheaters** against real humans: any bot can read `state.player_state["P1_WOOD_IN_HAND"]` or an opponent's hidden `ACTUAL_VICTORY_POINTS`. No human has that information.

## Design

The fair layer converges on one seam: **bot logic may depend only on an `Observation`, never on `Game`.** Three classes:

- **`Observation`** (`models/observation.py`) — a read-only, **pure-data snapshot** of exactly one color's information world: `features`, `public_history`, `current_prompt` / `current_trade` / `acceptees`. It holds **no reference to `Game` or `State`**, so the fairness boundary is structural — there is no handle to leak.
- **`ObservationAgent`** (`models/observation_agent.py`) — the fair bot base. Subclass it and implement `decide_observation(obs, playable_actions)`. Deliberately **not** a `Player`: it has no `decide(game, ...)`, no `is_bot`, and no engine dependency — the same class can be driven by a future site-mode adapter that builds observations from external Catan-site events.
- **`PerspectivePlayer`** (`models/perspective_player.py`) — the engine-side **adapter**. The game loop always requires a perfect-information state, so a fair agent *must* be wrapped in a `Player` subclass that converts `game` into an `Observation` each decision (features via `create_sample`, sanitized history, trade state) and delegates `reset_state()` to the agent.

## Why these decisions

- **`ObservationAgent` is not-a `Player`.** `Player` is a full-truth decider; declaring a fair agent is-a `Player` inherits a contract whose core assumption it deliberately violates. Decoupling also keeps the agent engine-independent (site mode), lets existing bots compose into it via a future `sample_hidden_state` hook, and keeps `decide(game, ...)` off the agent's surface.
- **`Observation` is pure data.** By moving `create_sample` (and history sanitization) into `PerspectivePlayer`, `Observation` needs no `Game`/`State` handle at all — the hard boundary becomes absolute, and the representation is identical in engine mode and deployed/site mode.
- **`features` is eager** (computed once per real decision, not lazily). It runs at decision time only, never inside the MCTS/playout hot path (which uses `game.copy()`), so the cost is negligible. Laziness would have required a closure that captures `Game` back onto the observation.
- **`public_history` is sanitized** by redacting hidden identities: opponent `BUY_DEVELOPMENT_CARD` (`value` + `result`) and `MOVE_ROBBER` stolen-card `result` unless the observer is the victim. Own records keep full detail. Discards are public per tournament convention (a single sanitizer switch covers future house rules).
- **Zero breaking changes.** Existing perfect-information bots, `json.py`, replay, accumulators, CLI, and gym all work unchanged.

## Usage

```python
from catanatron.game import Game
from catanatron.models.perspective_player import PerspectivePlayer
from catanatron.models.player import Color, RandomPlayer

game = Game(
    [
        PerspectivePlayer(CardCounterBot(Color.RED)),
        HumanPlayer(Color.BLUE),
        RandomPlayer(Color.ORANGE),
    ]
)
winner = game.play()
```

## Tests (`tests/test_observation.py` — 21 tests)

- **Structural separation:** `ObservationAgent` is not a `Player`; `Observation` carries no `_game`/`state`.
- **Leak-invariant surface scan** across seeded full games: opponent hand identities, opponent `ACTUAL_VICTORY_POINTS`, opponent dev-card purchases, and (for spectators) stolen-card identities are all absent.
- **Participant test:** the victim of a steal sees the stolen card in `public_history`; a spectator does not.
- **Sanitizer unit tests** per the redaction table.
- **Seam tests:** `Game([PerspectivePlayer(bot), ...])` plays to completion; bare agents via the `decide_fn` seam; `reset_state()` delegation.

## Follow-ups (deferred, not in this PR)

- `ObservationAgent.sample_hidden_state(obs) -> Game` belief-state hook, so fair agents can run the shipped perfect bots (MCTS/AlphaBeta) on their own sampled hypotheses of hidden state.
- An observation-log serializer and a real site-mode adapter (feed external events through `decide_observation`).
- `HumanPlayer` re-plumbed through the same seam (out of scope: humans already only perceive their own hand and the board).
