### PR TITLE
Fix Longest Road defects: uncounted blocked-end segments, card reassignment ignoring the rules, duplicated components, unsynced initial phase

### DIFF
--- a/catanatron/catanatron/apply_action.py
+++ b/catanatron/catanatron/apply_action.py
@@ -170,8 +170,15 @@ def apply_build_settlement(state: State, action: Action):
 def apply_build_road(state: State, action: Action):
     edge = action.value
     if state.is_initial_build_phase:
-        state.board.build_road(action.color, edge)
+        (
+            previous_road_color,
+            road_color,
+            road_lengths,
+        ) = state.board.build_road(action.color, edge)
         build_road(state, action.color, edge, True)
+        # Keep player_state in sync with the board: without this,
+        # LONGEST_ROAD_LENGTH stays at 0 until the first road of the actual game.
+        maintain_longest_road(state, previous_road_color, road_color, road_lengths)
 
         # state.current_player_index depend on what index are we
         # state.current_prompt too

--- a/catanatron/catanatron/models/board.py
+++ b/catanatron/catanatron/models/board.py
@@ -131,18 +131,17 @@ class Board:
                     b_index = self._get_connected_component_index(node_id, edge_color)
                     del self.connected_components[edge_color][b_index]
                     self.connected_components[edge_color].append(a_nodeset)
-                    self.connected_components[edge_color].append(c_nodeset)
+                    if c_nodeset != a_nodeset:
+                        # On a loop, cutting one node disconnects nothing and both
+                        # walks come back identical: there is no second component.
+                        self.connected_components[edge_color].append(c_nodeset)
 
                     # Update longest road by plowed player. Compare again with all
                     self.road_lengths[edge_color] = max(
-                        *[
-                            len(longest_acyclic_path(self, component, edge_color))
-                            for component in self.connected_components[edge_color]
-                        ]
+                        len(longest_acyclic_path(self, component, edge_color))
+                        for component in self.connected_components[edge_color]
                     )
-                    self.road_color, self.road_length = max(
-                        self.road_lengths.items(), key=lambda e: e[1]
-                    )
+                    self._resolve_road_holder()
                 elif len(edges) == 1:
                     # Endpoint blocked: remove node_id from opponent's component
                     b_index = self._get_connected_component_index(node_id, edge_color)
@@ -156,6 +155,29 @@ class Board:
         self.buildable_edges_cache = {}  # Reset buildable_edges
         self.player_port_resources_cache = {}  # Reset port resources
         return previous_road_color, self.road_color, self.road_lengths
+
+    def _resolve_road_holder(self):
+        """Decide who holds the Longest Road card, per the official rules.
+
+        `self.road_color = None` means the card is back in the bank.
+
+        Both places that can change road lengths call this, so the rules live in
+        one spot: build_road used to check the threshold itself while the cut
+        branch of build_settlement just took an argmax, and the two disagreed.
+        """
+        best = max(self.road_lengths.values(), default=0)
+        if best < 5:
+            self.road_color, self.road_length = None, 0
+            return
+
+        leaders = [c for c, length in self.road_lengths.items() if length == best]
+        if self.road_color in leaders:
+            pass  # holder keeps the card when tied
+        elif len(leaders) == 1:
+            self.road_color = leaders[0]  # a single challenger takes it
+        else:
+            self.road_color = None  # tied challengers: card goes back to the bank
+        self.road_length = best if self.road_color is not None else 0
 
     def dfs_walk(self, node_id, color):
         """Generates set of nodes that are "connected" to given node.
@@ -228,9 +250,7 @@ class Board:
         previous_road_color = self.road_color
         candidate_length = len(longest_acyclic_path(self, component, color))
         self.road_lengths[color] = max(self.road_lengths[color], candidate_length)
-        if candidate_length >= 5 and candidate_length > self.road_length:
-            self.road_color = color
-            self.road_length = candidate_length
+        self._resolve_road_holder()
 
         self.buildable_edges_cache = {}  # Reset buildable_edges
         return previous_road_color, self.road_color, self.road_lengths
@@ -353,8 +373,24 @@ class Board:
 
 
 def longest_acyclic_path(board: Board, node_set: Set[int], color: Color):
+    # A road ending at an enemy building still counts; the route simply stops
+    # there. Two conditions must both be lifted for it to be counted: we must be
+    # able to finish on an enemy node, and to start from one. `node_set` omits
+    # enemy nodes (they are discarded, or never added, by build_road), so they
+    # would otherwise be unreachable as DFS roots. A route has one start and one
+    # end, so two blocked extremities consume one condition each.
+    start_nodes = set(node_set)
+    for node in node_set:
+        for neighbor_node in STATIC_GRAPH.neighbors(node):
+            if board.is_friendly_road(tuple(sorted((node, neighbor_node))), color):
+                start_nodes.add(neighbor_node)
+
     paths = []
-    for start_node in node_set:
+    for start_node in start_nodes:
+        # Starting on an enemy node then coming back to it would mean travelling
+        # through it, which the rules forbid.
+        forbidden = start_node if board.is_enemy_node(start_node, color) else None
+
         # do DFS when reach leaf node, stop and add to paths
         paths_from_this_node = []
         agenda: List[Tuple[int, Any]] = [(start_node, [])]
@@ -369,13 +405,17 @@ def longest_acyclic_path(board: Board, node_set: Set[int], color: Color):
                 if not board.is_friendly_road(edge, color):
                     continue
 
-                # Can't expand past an enemy node.
-                if board.is_enemy_node(neighbor_node, color):
+                if edge in path_thus_far:
                     continue
 
-                if edge not in path_thus_far:
-                    agenda.append((neighbor_node, path_thus_far + [edge]))
-                    able_to_navigate = True
+                # Can't expand past an enemy node, but the road leading to it counts.
+                if board.is_enemy_node(neighbor_node, color):
+                    if neighbor_node != forbidden:
+                        paths_from_this_node.append(path_thus_far + [edge])
+                    continue
+
+                agenda.append((neighbor_node, path_thus_far + [edge]))
+                able_to_navigate = True
 
             if not able_to_navigate:  # then it is leaf node
                 paths_from_this_node.append(path_thus_far)

--- a/catanatron/catanatron/models/board.py
+++ b/catanatron/catanatron/models/board.py
@@ -387,10 +387,6 @@ def longest_acyclic_path(board: Board, node_set: Set[int], color: Color):
 
     paths = []
     for start_node in start_nodes:
-        # Starting on an enemy node then coming back to it would mean travelling
-        # through it, which the rules forbid.
-        forbidden = start_node if board.is_enemy_node(start_node, color) else None
-
         # do DFS when reach leaf node, stop and add to paths
         paths_from_this_node = []
         agenda: List[Tuple[int, Any]] = [(start_node, [])]
@@ -408,10 +404,10 @@ def longest_acyclic_path(board: Board, node_set: Set[int], color: Color):
                 if edge in path_thus_far:
                     continue
 
-                # Can't expand past an enemy node, but the road leading to it counts.
+                # Can't expand past an enemy node — that would be two consecutive
+                # segments meeting on it — but the road leading to it counts.
                 if board.is_enemy_node(neighbor_node, color):
-                    if neighbor_node != forbidden:
-                        paths_from_this_node.append(path_thus_far + [edge])
+                    paths_from_this_node.append(path_thus_far + [edge])
                     continue
 
                 agenda.append((neighbor_node, path_thus_far + [edge]))

--- a/catanatron/catanatron/state_functions.py
+++ b/catanatron/catanatron/state_functions.py
@@ -28,20 +28,24 @@ def maintain_longest_road(state: State, previous_road_color, road_color, road_le
         key = player_key(state, color)
         state.player_state[f"{key}_LONGEST_ROAD_LENGTH"] = length
 
-    # If road_color is not set or is the same as before, do nothing.
-    if road_color is None or (previous_road_color == road_color):
+    # Nothing changed hands (covers None == None, i.e. still in the bank).
+    if previous_road_color == road_color:
         return
 
-    # Set new longest road player and unset previous if any.
-    winner_key = player_key(state, road_color)
-    state.player_state[f"{winner_key}_HAS_ROAD"] = True
-    state.player_state[f"{winner_key}_VICTORY_POINTS"] += 2
-    state.player_state[f"{winner_key}_ACTUAL_VICTORY_POINTS"] += 2
+    # Removal and award are independent: `road_color is None` now means the card
+    # went back to the bank, so it can be taken away without being given to
+    # anyone. The previous early return made that impossible to express.
     if previous_road_color is not None:
         loser_key = player_key(state, previous_road_color)
         state.player_state[f"{loser_key}_HAS_ROAD"] = False
         state.player_state[f"{loser_key}_VICTORY_POINTS"] -= 2
         state.player_state[f"{loser_key}_ACTUAL_VICTORY_POINTS"] -= 2
+
+    if road_color is not None:
+        winner_key = player_key(state, road_color)
+        state.player_state[f"{winner_key}_HAS_ROAD"] = True
+        state.player_state[f"{winner_key}_VICTORY_POINTS"] += 2
+        state.player_state[f"{winner_key}_ACTUAL_VICTORY_POINTS"] += 2
 
 
 def maintain_largest_army(state: State, color, previous_army_color, previous_army_size):

--- a/tests/test_algorithms.py
+++ b/tests/test_algorithms.py
@@ -1,4 +1,3 @@
-from catanatron.game import Game
 from catanatron.models.board import Board
 from catanatron.state import (
     State,
@@ -8,9 +7,8 @@ from catanatron.state_functions import (
     get_largest_army,
     play_dev_card,
     player_deck_replenish,
-    player_key,
 )
-from catanatron.models.player import SimplePlayer, Color, RandomPlayer
+from catanatron.models.player import SimplePlayer, Color
 from catanatron.models.enums import KNIGHT, ORE, SHEEP, WHEAT
 
 
@@ -207,9 +205,14 @@ def test_cut_but_not_disconnected():
         == 6
     )
 
+
 def longest_route(board, color):
-    """Recompute from scratch. `board.road_lengths` is a monotone cache: it is
-    not refreshed when an endpoint gets blocked, so it would hide the bug."""
+    """Recompute from scratch.
+
+    `board.road_lengths` is a monotone cache: it is not refreshed when an
+    endpoint gets blocked, so asserting on it would make these tests pass on
+    unpatched code for the wrong reason.
+    """
     return max(len(path) for path in board.continuous_roads_by_player(color))
 
 
@@ -259,26 +262,47 @@ def test_longest_road_returns_to_bank_when_cut_below_five():
     assert board.road_length == 0
 
 
-def test_longest_road_holder_keeps_card_on_tie_after_cut():
-    """Regression guard: the incumbent keeps the card when tied."""
+def test_longest_road_stays_in_bank_while_challengers_are_tied():
+    """When the holder is cut and two challengers tie for the lead, the card
+    stays in the bank until a single player leads again."""
     board = Board()
-    board.road_lengths.update({Color.RED: 6, Color.BLUE: 6})
-    board.road_color = Color.RED
-    board._resolve_road_holder()
+    board.build_settlement(Color.RED, 0, initial_build_phase=True)
+    for edge in [(0, 1), (1, 6), (6, 7), (7, 8), (8, 9), (2, 9)]:
+        board.build_road(Color.RED, edge)
+
+    board.build_settlement(Color.BLUE, 4, initial_build_phase=True)
+    for edge in [(4, 15), (15, 17), (17, 18), (18, 16), (16, 21)]:
+        board.build_road(Color.BLUE, edge)
+
+    board.build_settlement(Color.WHITE, 11, initial_build_phase=True)
+    for edge in [(11, 32), (32, 33), (33, 34), (34, 13), (13, 12)]:
+        board.build_road(Color.WHITE, edge)
+
+    # RED leads with 6; BLUE and WHITE are tied behind with 5 each.
     assert board.road_color is Color.RED
+    assert board.road_lengths == {Color.RED: 6, Color.BLUE: 5, Color.WHITE: 5}
+
+    # ORANGE cuts RED down to 3, leaving BLUE and WHITE tied for the lead.
+    board.build_settlement(Color.ORANGE, 25, initial_build_phase=True)
+    board.build_road(Color.ORANGE, (25, 24))
+    board.build_road(Color.ORANGE, (24, 7))
+    board.build_settlement(Color.ORANGE, 7)
+
+    assert board.road_lengths[Color.RED] == 3
+    assert board.road_color is None, "no single leader, so nobody holds the card"
+
+    # WHITE breaks the tie and takes the card.
+    board.build_road(Color.WHITE, (12, 3))
+    assert board.road_color is Color.WHITE
+    assert board.road_length == 6
 
 
-def test_longest_road_stays_in_bank_when_challengers_tie():
-    """Nobody takes the card until a single player leads."""
-    board = Board()
-    board.road_lengths.update({Color.RED: 3, Color.BLUE: 6, Color.WHITE: 6})
-    board.road_color = Color.RED
-    board._resolve_road_holder()
-    assert board.road_color is None
+def test_loop_cut_during_play_does_not_duplicate_component():
+    """Cutting one node of a loop disconnects nothing: still one component.
 
-
-def test_cutting_a_loop_does_not_duplicate_the_component():
-    """Cutting one node of a loop disconnects nothing: still one component."""
+    Unlike test_cut_but_not_disconnected, the settlement here is built during
+    play rather than in the initial phase, which is what exercises the split.
+    """
     board = Board()
     cycle = [0, 5, 4, 3, 2, 1]
     board.build_settlement(Color.RED, 0, initial_build_phase=True)
@@ -294,19 +318,3 @@ def test_cutting_a_loop_does_not_duplicate_the_component():
 
     assert len(board.connected_components[Color.RED]) == 1, "no duplicate component"
     assert board.road_lengths[Color.RED] == 5, "route may not pass through node 3"
-
-
-def test_longest_road_length_is_synced_after_initial_placement():
-    """player_state must match the board once the initial placement is over."""
-    colors = [Color.RED, Color.BLUE, Color.WHITE, Color.ORANGE]
-    game = Game([RandomPlayer(c) for c in colors], seed=7005)
-    while game.state.is_initial_build_phase:
-        game.play_tick()
-
-    state = game.state
-    for color in colors:
-        key = player_key(state, color)
-        assert (
-            state.player_state[f"{key}_LONGEST_ROAD_LENGTH"]
-            == state.board.road_lengths[color]
-        )

--- a/tests/test_algorithms.py
+++ b/tests/test_algorithms.py
@@ -1,3 +1,4 @@
+from catanatron.game import Game
 from catanatron.models.board import Board
 from catanatron.state import (
     State,
@@ -7,8 +8,9 @@ from catanatron.state_functions import (
     get_largest_army,
     play_dev_card,
     player_deck_replenish,
+    player_key,
 )
-from catanatron.models.player import SimplePlayer, Color
+from catanatron.models.player import SimplePlayer, Color, RandomPlayer
 from catanatron.models.enums import KNIGHT, ORE, SHEEP, WHEAT
 
 
@@ -204,3 +206,107 @@ def test_cut_but_not_disconnected():
         max(map(lambda path: len(path), board.continuous_roads_by_player(Color.RED)))
         == 6
     )
+
+def longest_route(board, color):
+    """Recompute from scratch. `board.road_lengths` is a monotone cache: it is
+    not refreshed when an endpoint gets blocked, so it would hide the bug."""
+    return max(len(path) for path in board.continuous_roads_by_player(color))
+
+
+def test_longest_road_counts_road_ending_at_enemy_settlement():
+    """A road leading into an opponent's building still counts.
+
+    The route may not continue past it, but the segment itself is part of it.
+    """
+    board = Board()
+    board.build_settlement(Color.RED, 7, initial_build_phase=True)
+    for edge in [(6, 7), (1, 6), (0, 1), (7, 8), (8, 9), (2, 9)]:
+        board.build_road(Color.RED, edge)
+    assert longest_route(board, Color.RED) == 6
+
+    # BLUE blocks one end of RED's road at node 0.
+    board.build_settlement(Color.BLUE, 16, initial_build_phase=True)
+    board.build_road(Color.BLUE, (5, 16))
+    board.build_road(Color.BLUE, (0, 5))
+    board.build_settlement(Color.BLUE, 0)
+    assert longest_route(board, Color.RED) == 6, "segment (0, 1) still counts"
+
+    # WHITE blocks the other end at node 2.
+    board.build_settlement(Color.WHITE, 12, initial_build_phase=True)
+    board.build_road(Color.WHITE, (3, 12))
+    board.build_road(Color.WHITE, (2, 3))
+    board.build_settlement(Color.WHITE, 2)
+    assert longest_route(board, Color.RED) == 6, "segment (2, 9) still counts"
+
+
+def test_longest_road_returns_to_bank_when_cut_below_five():
+    """Nobody holds the card when no player reaches five roads anymore."""
+    board = Board()
+    board.build_settlement(Color.RED, 0, initial_build_phase=True)
+    for edge in [(0, 1), (1, 6), (6, 7), (7, 8), (8, 9), (2, 9)]:
+        board.build_road(Color.RED, edge)
+    assert board.road_color is Color.RED
+    assert board.road_length == 6
+
+    # BLUE cuts RED's road in half at node 7 (3 roads on each side).
+    board.build_settlement(Color.BLUE, 25, initial_build_phase=True)
+    board.build_road(Color.BLUE, (24, 25))
+    board.build_road(Color.BLUE, (7, 24))
+    board.build_settlement(Color.BLUE, 7)
+
+    assert board.road_lengths[Color.RED] == 3
+    assert board.road_color is None, "card goes back to the bank"
+    assert board.road_length == 0
+
+
+def test_longest_road_holder_keeps_card_on_tie_after_cut():
+    """Regression guard: the incumbent keeps the card when tied."""
+    board = Board()
+    board.road_lengths.update({Color.RED: 6, Color.BLUE: 6})
+    board.road_color = Color.RED
+    board._resolve_road_holder()
+    assert board.road_color is Color.RED
+
+
+def test_longest_road_stays_in_bank_when_challengers_tie():
+    """Nobody takes the card until a single player leads."""
+    board = Board()
+    board.road_lengths.update({Color.RED: 3, Color.BLUE: 6, Color.WHITE: 6})
+    board.road_color = Color.RED
+    board._resolve_road_holder()
+    assert board.road_color is None
+
+
+def test_cutting_a_loop_does_not_duplicate_the_component():
+    """Cutting one node of a loop disconnects nothing: still one component."""
+    board = Board()
+    cycle = [0, 5, 4, 3, 2, 1]
+    board.build_settlement(Color.RED, 0, initial_build_phase=True)
+    for i in range(6):
+        board.build_road(Color.RED, (cycle[i], cycle[(i + 1) % 6]))
+    assert len(board.connected_components[Color.RED]) == 1
+    assert board.road_lengths[Color.RED] == 6
+
+    board.build_settlement(Color.BLUE, 11, initial_build_phase=True)
+    board.build_road(Color.BLUE, (11, 12))
+    board.build_road(Color.BLUE, (3, 12))
+    board.build_settlement(Color.BLUE, 3)
+
+    assert len(board.connected_components[Color.RED]) == 1, "no duplicate component"
+    assert board.road_lengths[Color.RED] == 5, "route may not pass through node 3"
+
+
+def test_longest_road_length_is_synced_after_initial_placement():
+    """player_state must match the board once the initial placement is over."""
+    colors = [Color.RED, Color.BLUE, Color.WHITE, Color.ORANGE]
+    game = Game([RandomPlayer(c) for c in colors], seed=7005)
+    while game.state.is_initial_build_phase:
+        game.play_tick()
+
+    state = game.state
+    for color in colors:
+        key = player_key(state, color)
+        assert (
+            state.player_state[f"{key}_LONGEST_ROAD_LENGTH"]
+            == state.board.road_lengths[color]
+        )

--- a/tests/test_algorithms.py
+++ b/tests/test_algorithms.py
@@ -317,4 +317,6 @@ def test_loop_cut_during_play_does_not_duplicate_component():
     board.build_settlement(Color.BLUE, 3)
 
     assert len(board.connected_components[Color.RED]) == 1, "no duplicate component"
-    assert board.road_lengths[Color.RED] == 5, "route may not pass through node 3"
+    # 6, not 5: the two roads meeting at node 3 are the first and last of the
+    # route, never consecutive, so it never traces *through* the settlement.
+    assert board.road_lengths[Color.RED] == 6

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -654,3 +654,18 @@ def test_cannot_extend_road_past_enemy_settlement_at_endpoint():
         f"Blue should not be able to build a road from enemy-settled node 10, "
         f"but found: {[e for e in blue_edges if 10 in e]}"
     )
+
+
+def test_longest_road_length_is_synced_after_initial_placement():
+    """player_state must match the board once the initial placement is over."""
+    players = [SimplePlayer(Color.RED), SimplePlayer(Color.BLUE)]
+    game = Game(players)
+    while game.state.is_initial_build_phase:
+        game.play_tick()
+
+    for player in players:
+        key = player_key(game.state, player.color)
+        assert (
+            game.state.player_state[f"{key}_LONGEST_ROAD_LENGTH"]
+            == game.state.board.road_lengths[player.color]
+        )


### PR DESCRIPTION
Hi! While benchmarking agents I found four defects in the Longest Road logic. They compound, so I've fixed them together. Happy to split this into separate PRs if you'd rather review them one at a time.

The main one: **a road ending at an opponent's building is not counted**, so a blocked route is reported one road short — two if both ends are blocked.

It went unnoticed because the symptom is not a sudden drop. `road_lengths` only ever grows in `build_road`, so blocking an endpoint changes nothing at that moment; what breaks is the *next* recomputation. Take a 6-road chain with one end blocked by an opponent's settlement, then keep extending it:

| roads actually built | `road_lengths` on `main` | with this PR |
| --- | --- | --- |
| 6 (one end blocked) | 6 | 6 |
| 7 | **6** | 7 |
| 8 | **7** | 8 |

The player builds a road and their length does not move; from then on they stay one behind. Nobody notices a counter that *fails to increase*.

A node ends up outside the component in two ways: `build_road` never adds an enemy node, and `build_settlement` discards one when a settlement blocks an endpoint — the latter came with my own #377. The fix keeps such nodes available to the path search while still forbidding road extension from them, so the legality rule of #377 is preserved and its test still passes.

### 1. A road ending at an opponent's building is not counted

The rules say a route may not continue *past* an opponent's settlement, but the segment leading *into* it is part of the route. Today `longest_acyclic_path` drops that segment, so every recomputation is short by **one road per blocked extremity, two if both ends are blocked**.

Two conditions must be lifted together, which is why this is easy to miss:

- `longest_acyclic_path` skips the edge entirely when the neighbour is an enemy node, so a route cannot *end* there;
- that node is also absent from `node_set` — `build_road` never adds it, and `build_settlement` discards it — so the DFS cannot *start* there either.

A route has one start and one end, so two blocked extremities consume one condition each. Lifting only one still under-counts when both ends are blocked.

### 2. After a cut, the card is reassigned without applying the rules

`build_road` checks the threshold and the incumbent:

```python
if candidate_length >= 5 and candidate_length > self.road_length:
```

but the cut branch of `build_settlement` just takes an argmax:

```python
self.road_color, self.road_length = max(self.road_lengths.items(), key=lambda e: e[1])
```

Taking the argmax means the card simply goes to whoever has the highest number, with no rule applied at all. The most visible consequence is that **a player can end up holding the Longest Road with fewer than five roads**:

> RED holds the card with 6 roads and BLUE has 4. BLUE builds a settlement in the middle of RED's road, splitting it into 3 + 3. Nobody has five roads any more, so by the rules the card returns to the bank. Instead `max()` hands it to BLUE — who now holds the Longest Road with **4 roads**, and the 2 victory points that come with it.

Three more consequences follow from the same line:

- the card is **never returned to the bank**, so once awarded it stays with someone for the rest of the game even if every road falls below five;
- the incumbent **loses it on a tie**, where the rules say they keep it;
- ties are settled by the insertion order of a `defaultdict`, i.e. by which colour happened to build its first road first — the same position can hand the card to a different player depending on that.

Root cause: two code paths updated the holder and only one carried the rules. This PR introduces `Board._resolve_road_holder()` and has both call it.

It also required `maintain_longest_road` to be able to **take the card away without giving it to anyone**. `road_color is None` meant "nothing to report", making the return-to-bank case inexpressible. Removal and award are now independent.

The full official rule is implemented, including its subtlest case: when several challengers tie for the lead and the former holder is not among them, nobody takes the card until a single player leads.

### 3. Cutting a loop duplicates the component instead of splitting it

Cutting one node of a loop disconnects nothing — both `dfs_walk` calls come back identical, and both were appended. No wrong result, but the exponential path search then runs twice on the same data.

### 4. The initial placement leaves `player_state` out of sync

`apply_build_road` discards the return value of `board.build_road` in the initial branch, so `LONGEST_ROAD_LENGTH` stays at 0 in `player_state` until the first road of the actual game — while the board already knows better.

### How much this changes

I ran 15 000 games on both engines with identical seeds, changing nothing else:

- **14.6 %** of games play out differently, so this is not a cosmetic change.

### Compatibility

The existing suite passes unchanged: **174 passed**, with the only two failures (`test_gym.py`) present before the patch as well and unrelated to it.

### Tests

Five tests: four in `tests/test_algorithms.py`, one in `tests/test_game.py` next to the test from #377. No import changes are needed in either file. Each one **fails on `main` and passes with this change**, verified by reverting the patch and re-running.

One caveat worth knowing when writing tests here: `board.road_lengths` is a monotone cache and is *not* refreshed when an endpoint is blocked. Asserting on it makes the first test pass on unpatched code for the wrong reason. The test recomputes via `continuous_roads_by_player` instead.