### PR TITLE
fix: chance-node branches never produce the outcome they were built for

### DIFF
--- a/catanatron/catanatron/players/tree_search_utils.py
+++ b/catanatron/catanatron/players/tree_search_utils.py
@@ -63,7 +63,11 @@ def execute_spectrum(game: Game, action: Action):
             option_action = Action(action.color, action.action_type, card)
             option_game = game.copy()
             try:
-                option_game.execute(option_action, validate_action=False)
+                option_game.execute(
+                    option_action,
+                    validate_action=False,
+                    action_record=ActionRecord(action=option_action, result=card),
+                )
             except Exception:
                 # ignore exceptions, since player might imagine impossible outcomes.
                 # ignoring means the value function of this node will be flattened,
@@ -78,7 +82,11 @@ def execute_spectrum(game: Game, action: Action):
 
             option_action = Action(action.color, action.action_type, outcome)
             option_game = game.copy()
-            option_game.execute(option_action, validate_action=False)
+            option_game.execute(
+                option_action,
+                validate_action=False,
+                action_record=ActionRecord(action=option_action, result=outcome),
+            )
             results.append((option_game, number_probability(roll)))
         return results
     elif action.action_type == ActionType.MOVE_ROBBER:


### PR DESCRIPTION
`execute_spectrum` builds one `Action` per possible outcome for the two
stochastic action types and executes it. For `MOVE_ROBBER` the outcome is
passed through `ActionRecord.result` and works correctly. For
`BUY_DEVELOPMENT_CARD` and `ROLL` the outcome is only put in `action.value`
— and `apply_action` ignores `action.value` for both:

```python
# apply_buy_development_card
card = state.development_listdeck.pop() if action_record is None else action_record.result

# apply_roll
dices = action_record.result if action_record is not None else roll_dice()
```

So neither branch produces the outcome it was built for.

### `BUY_DEVELOPMENT_CARD` — every branch holds the same card

`development_listdeck` is shuffled once at init and `State.copy()` copies the
list, so each branch pops the *same* top card: the one the real buy will draw.
The node has N probabilities and one outcome, and the expectation collapses
onto the true card — i.e. the search values the purchase already knowing what
it will get.

```
CURRENT: 5 branches, 1 distinct outcome(s)
FIXED:   5 branches, 5 distinct outcome(s)
```

### `ROLL` — every branch rolls a fresh random number

`roll_dice()` is called per branch, so each outcome gets a random roll
unrelated to the `number_probability(roll)` weight it was assigned. The
expectation weights the wrong states, and each expansion also consumes 11
draws from the global RNG.

```
   label   proba   actual dice in the resulting state
       2   0.028       (5, 5) = 10   <-- NOT the labelled outcome
       3   0.056       (5, 3) = 8    <-- NOT the labelled outcome
       4   0.083       (4, 1) = 5    <-- NOT the labelled outcome
       ...
  branches whose actual roll matches their label: 0 of 11
```

After the fix: 11 of 11 match.

### Fix

Pass the intended outcome through `ActionRecord.result`, exactly as the
`MOVE_ROBBER` branch a few lines below already does. No behavioural change to
`MOVE_ROBBER` or the deterministic path.

### Impact

`AlphaBetaPlayer` and `MCTSPlayer` both expand chance nodes through this
function, so both currently average over outcomes that do not correspond to
their probabilities.

### Reproducing

Both checks above are runnable against a clean checkout; I verified them on
`main` (`d3f4ad0`) before and after the patch. Happy to add them as tests if
you would like them in the suite — I left them out to keep the diff to the
fix itself.

```python
from catanatron import Color, Game
from catanatron.models.enums import ActionType
from catanatron.players.tree_search_utils import expand_spectrum
from catanatron.players.value import ValueFunctionPlayer

SEATS = [Color.RED, Color.BLUE, Color.WHITE, Color.ORANGE]
game = Game([ValueFunctionPlayer(c) for c in SEATS], seed=0)
while not any(a.action_type == ActionType.ROLL for a in game.playable_actions):
    game.play_tick()
roll = next(a for a in game.playable_actions if a.action_type == ActionType.ROLL)
before = len(game.state.action_records)
for (outcome, proba), label in zip(expand_spectrum(game, [roll])[roll], range(2, 13)):
    rec = outcome.state.action_records[before]
    print(label, proba, rec.result or rec.action.value)
```

Found while auditing why a bot of mine valued development-card purchases
bimodally; it turned out to be reading the top of the deck through the search.
