### PR TITLE
3.35× Throughput Improvement (Extending #382)

### DIFF
--- a/catanatron/catanatron/features.py
+++ b/catanatron/catanatron/features.py
@@ -332,11 +332,15 @@ def get_owned_or_buildable(game, color, board_buildable):
     )
 
 
-def reachability_features(game: Game, p0_color: Color, levels=REACHABLE_FEATURES_MAX):
+def reachability_features(
+    game: Game, p0_color: Color, levels=REACHABLE_FEATURES_MAX, *, only_p0=False
+):
+    """Road reachability; optionally extract just the perspective player."""
     features = {}
 
     board_buildable = game.state.board.buildable_node_ids(p0_color, True)
-    for i, color in iter_players(game.state.colors, p0_color):
+    players = [(0, p0_color)] if only_p0 else iter_players(game.state.colors, p0_color)
+    for i, color in players:
         owned_or_buildable = get_owned_or_buildable(game, color, board_buildable)
 
         # do layer 0

--- a/catanatron/catanatron/game.py
+++ b/catanatron/catanatron/game.py
@@ -95,9 +95,13 @@ class Game:
         #: The subset that overrides step(), so the per-action loop skips
         #: players that only decide. Purely an optimization.
         self._steppers = []
+        # Always present: `copy()` reads both unconditionally, so leaving them
+        # to the `initialize` branch makes a Game(initialize=False) -- the way
+        # an adapter builds a mirror of a foreign engine's position -- fail to
+        # copy, and AlphaBeta copies before it searches.
+        self.seed = seed if seed is not None else random.randrange(sys.maxsize)
+        self.random = random.Random(self.seed)
         if initialize:
-            self.seed = seed if seed is not None else random.randrange(sys.maxsize)
-            self.random = random.Random(self.seed)
 
             self.id = str(uuid.uuid4())
             self.vps_to_win = vps_to_win

--- a/catanatron/catanatron/models/board.py
+++ b/catanatron/catanatron/models/board.py
@@ -1,5 +1,3 @@
-import pickle
-import copy
 from collections import defaultdict
 from typing import Any, Set, Dict, Tuple, List
 import functools
@@ -306,8 +304,13 @@ class Board:
         board.map = self.map  # reuse since its immutable
         board.buildings = self.buildings.copy()
         board.roads = self.roads.copy()
-        board.connected_components = pickle.loads(
-            pickle.dumps(self.connected_components)
+        # Rebuild sets in iteration order, as the pickle round trip did.
+        board.connected_components = defaultdict(
+            self.connected_components.default_factory,
+            (
+                (color, [set(list(nodes)) for nodes in components])
+                for color, components in self.connected_components.items()
+            ),
         )
         board.board_buildable_ids = self.board_buildable_ids.copy()
         board.road_lengths = self.road_lengths.copy()
@@ -316,10 +319,13 @@ class Board:
 
         board.robber_coordinate = self.robber_coordinate
         board.buildable_subgraph = self.buildable_subgraph
-        board.buildable_edges_cache = copy.deepcopy(self.buildable_edges_cache)
-        board.player_port_resources_cache = copy.deepcopy(
-            self.player_port_resources_cache
-        )
+        board.buildable_edges_cache = {
+            color: list(edges) for color, edges in self.buildable_edges_cache.items()
+        }
+        board.player_port_resources_cache = {
+            color: set(list(resources))
+            for color, resources in self.player_port_resources_cache.items()
+        }
         return board
 
     # ===== Helper functions

--- a/catanatron/catanatron/players/minimax.py
+++ b/catanatron/catanatron/players/minimax.py
@@ -1,4 +1,5 @@
 import time
+from functools import cached_property
 from dataclasses import dataclass, field
 from typing import Any, Literal, Optional
 
@@ -8,6 +9,7 @@ from catanatron.players.tree_search_utils import expand_spectrum, list_prunned_a
 from catanatron.players.value import (
     DEFAULT_WEIGHTS,
     get_value_fn,
+    BoardFeatureCache,
 )
 
 ALPHABETA_DEFAULT_DEPTH = 2
@@ -43,6 +45,10 @@ class AlphaBetaPlayer(Player):
     @property
     def value_fn_builder_name(self):
         return "contender_fn" if self.params.value_fn == "contender" else "base_fn"
+
+    @cached_property
+    def _board_feature_cache(self):
+        return BoardFeatureCache()
 
     def value_function(self, game, p0_color):
         raise NotImplementedError
@@ -90,6 +96,7 @@ class AlphaBetaPlayer(Player):
                 self.value_fn_builder_name,
                 self.params.weights,
                 self.value_function if self.use_value_function else None,
+                cache=self._board_feature_cache,
             )
             value = value_fn(game, self.color)
 
@@ -245,6 +252,7 @@ class SameTurnAlphaBetaPlayer(AlphaBetaPlayer):
                 self.value_fn_builder_name,
                 self.params.weights,
                 self.value_function if self.use_value_function else None,
+                cache=self._board_feature_cache,
             )
             value = value_fn(game, self.color)
 

--- a/catanatron/catanatron/players/value.py
+++ b/catanatron/catanatron/players/value.py
@@ -59,10 +59,9 @@ CONTENDER_WEIGHTS = {
 def base_fn(params=DEFAULT_WEIGHTS):
     def fn(game, p0_color):
         production_features = build_production_features(True)
-        our_production_sample = production_features(game, p0_color)
-        enemy_production_sample = production_features(game, p0_color)
-        production = value_production(our_production_sample, "P0")
-        enemy_production = value_production(enemy_production_sample, "P1", False)
+        production_sample = production_features(game, p0_color)
+        production = value_production(production_sample, "P0")
+        enemy_production = value_production(production_sample, "P1", False)
 
         key = player_key(game.state, p0_color)
         longest_road_length = get_longest_road_length(game.state, p0_color)

--- a/catanatron/catanatron/players/value.py
+++ b/catanatron/catanatron/players/value.py
@@ -1,3 +1,4 @@
+from functools import cached_property
 from dataclasses import dataclass
 from typing import Literal, Optional
 
@@ -14,7 +15,6 @@ from catanatron.models.enums import RESOURCES, SETTLEMENT, CITY
 from catanatron.features import (
     build_production_features,
     reachability_features,
-    resource_hand_features,
 )
 
 TRANSLATE_VARIETY = 4  # i.e. each new resource is like 4 production points
@@ -56,49 +56,40 @@ CONTENDER_WEIGHTS = {
 }
 
 
-def base_fn(params=DEFAULT_WEIGHTS):
+def base_fn(params=DEFAULT_WEIGHTS, *, cache=None):
     def fn(game, p0_color):
-        production_features = build_production_features(True)
-        production_sample = production_features(game, p0_color)
-        production = value_production(production_sample, "P0")
-        enemy_production = value_production(production_sample, "P1", False)
-
+        (
+            production,
+            enemy_production,
+            reachable_production_at_zero,
+            reachable_production_at_one,
+            num_tiles,
+            num_buildable_nodes,
+        ) = (
+            cache.terms(game, p0_color)
+            if cache is not None
+            else _board_terms(game, p0_color)
+        )
         key = player_key(game.state, p0_color)
         longest_road_length = get_longest_road_length(game.state, p0_color)
 
-        reachability_sample = reachability_features(game, p0_color, 2)
-        features = [f"P0_0_ROAD_REACHABLE_{resource}" for resource in RESOURCES]
-        reachable_production_at_zero = sum([reachability_sample[f] for f in features])
-        features = [f"P0_1_ROAD_REACHABLE_{resource}" for resource in RESOURCES]
-        reachable_production_at_one = sum([reachability_sample[f] for f in features])
-
-        hand_sample = resource_hand_features(game, p0_color)
-        features = [f"P0_{resource}_IN_HAND" for resource in RESOURCES]
+        player_state = game.state.player_state
+        wheat = player_state[key + "_WHEAT_IN_HAND"]
+        ore = player_state[key + "_ORE_IN_HAND"]
+        sheep = player_state[key + "_SHEEP_IN_HAND"]
+        brick = player_state[key + "_BRICK_IN_HAND"]
+        wood = player_state[key + "_WOOD_IN_HAND"]
         distance_to_city = (
-            max(2 - hand_sample["P0_WHEAT_IN_HAND"], 0)
-            + max(3 - hand_sample["P0_ORE_IN_HAND"], 0)
+            max(2 - wheat, 0) + max(3 - ore, 0)
         ) / 5.0  # 0 means good. 1 means bad.
         distance_to_settlement = (
-            max(1 - hand_sample["P0_WHEAT_IN_HAND"], 0)
-            + max(1 - hand_sample["P0_SHEEP_IN_HAND"], 0)
-            + max(1 - hand_sample["P0_BRICK_IN_HAND"], 0)
-            + max(1 - hand_sample["P0_WOOD_IN_HAND"], 0)
+            max(1 - wheat, 0) + max(1 - sheep, 0) + max(1 - brick, 0) + max(1 - wood, 0)
         ) / 4.0  # 0 means good. 1 means bad.
         hand_synergy = (2 - distance_to_city - distance_to_settlement) / 2
 
         num_in_hand = player_num_resource_cards(game.state, p0_color)
         discard_penalty = params["discard_penalty"] if num_in_hand > 7 else 0
 
-        # blockability
-        buildings = game.state.buildings_by_color[p0_color]
-        owned_nodes = buildings[SETTLEMENT] + buildings[CITY]
-        owned_tiles = set()
-        for n in owned_nodes:
-            owned_tiles.update(game.state.board.map.adjacent_tiles[n])
-        num_tiles = len(owned_tiles)
-
-        # TODO: Simplify to linear(?)
-        num_buildable_nodes = len(game.state.board.buildable_node_ids(p0_color))
         longest_road_factor = (
             params["longest_road"] if num_buildable_nodes == 0 else 0.1
         )
@@ -138,8 +129,108 @@ def value_production(sample, player_name="P0", include_variety=True):
     return prod_sum + (0 if not include_variety else prod_variety)
 
 
-def contender_fn(params):
-    return base_fn(params or CONTENDER_WEIGHTS)
+_production_features = build_production_features(True)
+
+
+def _board_terms(game, color):
+    # Native base_fn computes this same production sample twice.
+    sample = _production_features(game, color)
+    production = value_production(sample, "P0")
+    enemy_production = value_production(sample, "P1", False)
+    reach = reachability_features(game, color, 1, only_p0=True)
+    zero = sum([reach[f"P0_0_ROAD_REACHABLE_{r}"] for r in RESOURCES])
+    one = sum([reach[f"P0_1_ROAD_REACHABLE_{r}"] for r in RESOURCES])
+    buildings = game.state.buildings_by_color[color]
+    tiles = set()
+    for node in buildings[SETTLEMENT] + buildings[CITY]:
+        tiles.update(game.state.board.map.adjacent_tiles[node])
+    return (
+        production,
+        enemy_production,
+        zero,
+        one,
+        len(tiles),
+        len(game.state.board.buildable_node_ids(color)),
+    )
+
+
+class BoardFeatureCache:
+    """Bounded cache owned by one player and reused across its decisions.
+
+    Map objects are retained and a map change clears entries. Ordered building
+    lists preserve floating-point summation order. Component node iteration is
+    retained because native reachability unions sets before summing production.
+    Hands, VP, army, dev cards and longest-road length are read live, outside
+    this cache. No game objects, final scores or search bounds are retained.
+    """
+
+    def __init__(self, max_entries=4096):
+        if max_entries < 1:
+            raise ValueError("max_entries must be positive")
+        self.max_entries = max_entries
+        self.colors = None
+        self.map = None
+        self.entries = {}
+        self.hits = 0
+        self.misses = 0
+
+    def terms(self, game, color):
+        state = game.state
+        board = state.board
+        if board.map is not self.map or state.colors != self.colors:
+            self.entries.clear()
+            self.map = board.map
+            self.colors = state.colors
+        # Cache the inputs actually consumed by the board terms. Enemy
+        # ownership identity/type is irrelevant to P0 reachability; its
+        # node/edge blockers are sufficient. Ordered per-seat buildings
+        # still identify production for every color and relative P1.
+        key = (
+            color.value,
+            board.robber_coordinate,
+            tuple(
+                (
+                    tuple(state.buildings_by_color[c][SETTLEMENT]),
+                    tuple(state.buildings_by_color[c][CITY]),
+                )
+                for c in self.colors
+            ),
+            frozenset(
+                n
+                for n, owner in board.buildings.items()
+                if owner is not None and owner[0] != color
+            ),
+            frozenset(
+                e
+                for e, owner in board.roads.items()
+                if owner is not None and owner != color
+            ),
+            tuple(tuple(component) for component in board.connected_components[color]),
+            tuple(board.board_buildable_ids),
+        )
+        value = self.entries.get(key)
+        if value is not None:
+            self.hits += 1
+            return value
+        self.misses += 1
+        value = _board_terms(game, color)
+        if len(self.entries) >= self.max_entries:
+            # FIFO bounds memory without updating an LRU chain at every leaf.
+            del self.entries[next(iter(self.entries))]
+        self.entries[key] = value
+        return value
+
+    def stats(self):
+        return {
+            "hits": self.hits,
+            "misses": self.misses,
+            "entries": len(self.entries),
+            "max_entries": self.max_entries,
+        }
+
+
+def contender_fn(params, *, cache=None):
+    return base_fn(params or CONTENDER_WEIGHTS, cache=cache)
 
 
 class ValueFunctionPlayer(Player):
@@ -162,6 +253,10 @@ class ValueFunctionPlayer(Player):
     def value_fn_builder_name(self):
         return "contender_fn" if self.params.value_fn == "contender" else "base_fn"
 
+    @cached_property
+    def _board_feature_cache(self):
+        return BoardFeatureCache()
+
     def decide(self, game, playable_actions):
         if len(playable_actions) == 1:
             return playable_actions[0]
@@ -176,7 +271,11 @@ class ValueFunctionPlayer(Player):
             game_copy = game.copy()
             game_copy.execute(action)
 
-            value_fn = get_value_fn(self.value_fn_builder_name, self.params.weights)
+            value_fn = get_value_fn(
+                self.value_fn_builder_name,
+                self.params.weights,
+                cache=self._board_feature_cache,
+            )
             value = value_fn(game_copy, self.color)
             if value > best_value:
                 best_value = value
@@ -185,12 +284,12 @@ class ValueFunctionPlayer(Player):
         return best_action
 
 
-def get_value_fn(name, params, value_function=None):
+def get_value_fn(name, params, value_function=None, *, cache=None):
     if value_function is not None:
         return value_function
     elif name == "base_fn":
-        return base_fn(DEFAULT_WEIGHTS)
+        return base_fn(DEFAULT_WEIGHTS, cache=cache)
     elif name == "contender_fn":
-        return contender_fn(params)
+        return contender_fn(params, cache=cache)
     else:
         raise ValueError

--- a/catanatron/catanatron/state.py
+++ b/catanatron/catanatron/state.py
@@ -94,8 +94,12 @@ class State:
         initialize=True,
         rng=None,
     ):
+        # Always present, for the same reason as `Game.seed`/`Game.random`:
+        # `copy()` reads it unconditionally, so a State(initialize=False) --
+        # how an adapter mirrors a foreign engine's position -- could not be
+        # copied, and AlphaBeta copies before it searches.
+        self.random = rng if rng is not None else random.Random()
         if initialize:
-            self.random = rng if rng is not None else random.Random()
             self.players = self.random.sample(players, len(players))
             self.colors = tuple([player.color for player in self.players])
             self.board = Board(

--- a/catanatron/catanatron/state.py
+++ b/catanatron/catanatron/state.py
@@ -1,4 +1,3 @@
-import pickle
 import random
 from collections import defaultdict
 from typing import Any, Dict, List, Sequence, Tuple
@@ -178,9 +177,13 @@ class State:
         state_copy.resource_freqdeck = self.resource_freqdeck.copy()
         state_copy.development_listdeck = self.development_listdeck.copy()
 
-        state_copy.buildings_by_color = pickle.loads(
-            pickle.dumps(self.buildings_by_color)
-        )
+        state_copy.buildings_by_color = {
+            color: defaultdict(
+                buildings.default_factory,
+                ((kind, nodes.copy()) for kind, nodes in buildings.items()),
+            )
+            for color, buildings in self.buildings_by_color.items()
+        }
         state_copy.action_records = self.action_records.copy()
         state_copy.num_turns = self.num_turns
 

--- a/docs/performance/value-speedups/README.md
+++ b/docs/performance/value-speedups/README.md
@@ -2,7 +2,7 @@
 
 Prepared September 11, 2026 UTC. Branch `perf/native-evaluator-speedups` is based
 on latest upstream `ecf931181b9a65bb4116a2153fb78c16f1438e00`, checked directly
-against GitHub. The PR is prepared for submission with the user's approval.
+against GitHub. Published as [PR #389](https://github.com/bcollazo/catanatron/pull/389).
 
 GitHub has no published releases or tags. PyPI's latest release is
 [3.2.1, published July 17, 2022](https://pypi.org/project/catanatron/3.2.1/).

--- a/docs/performance/value-speedups/README.md
+++ b/docs/performance/value-speedups/README.md
@@ -1,0 +1,91 @@
+# Local upstream performance candidate
+
+Prepared September 11, 2026 UTC. Branch `perf/native-evaluator-speedups` is based
+on latest upstream `ecf931181b9a65bb4116a2153fb78c16f1438e00`, checked directly
+against GitHub. The PR is prepared for submission with the user's approval.
+
+GitHub has no published releases or tags. PyPI's latest release is
+[3.2.1, published July 17, 2022](https://pypi.org/project/catanatron/3.2.1/).
+Current GitHub source declares 3.3.0 and is the relevant base for a future PR.
+HexSet's previous benchmark pin, `d3f4ad05bb78d8b2309631d6d3cfa8fcb6fda816`,
+is two commits behind this base. The two newer commits introduce per-game RNG
+and the bot registry/lifecycle API; this branch preserves both, including the
+intentional shared RNG reference in State.copy. Historical HexSet results
+remain tied to their original pin and must not be relabeled as latest-upstream
+measurements.
+
+## Changes and prior work
+
+The first commit is cherry-picked from [#382](https://github.com/bcollazo/catanatron/pull/382)
+by Honesty Bot, preserving its original authorship. It removes the duplicate
+production-feature calculation. That contribution is included here explicitly;
+we do not claim it as new work. This PR can follow #382 if it lands first.
+
+The subsequent change adds structural state/board copies, perspective-only hand
+and reachability extraction, and bounded board-feature caches owned by individual
+AB/ValueFunction players. Caches clear when maps or seating change. Dynamic hands,
+VP, development cards, army and longest road remain live reads. Full public
+feature extraction retains its default behavior. No global patch context,
+HexSet dependency, heuristic weights, action ordering, pruning or search deadline
+is changed.
+
+Related performance work: [#371](https://github.com/bcollazo/catanatron/pull/371)
+optimizes MCTS playouts, enum hashing and longest-road traversal. This change
+keeps enum representations and the road algorithm unchanged. The maintainer's
+Rust work in [#387](https://github.com/bcollazo/catanatron/pull/387) is separate
+from this Python implementation.
+
+The tested implementation is byte-identical to the measured source at local
+commit `48aeb7d7512aade72df2a13a17a94e2ad667542c`; commit history was reorganized
+to preserve #382 authorship before submission. The benchmark retains a frozen
+pre-change scalar oracle. The headline timings include the benefit of #382;
+they are not an attribution to the additional work alone.
+
+## Latest-upstream paired check
+
+Pinned Python 3.12.14 Wintermute runtime, one CPU, fresh interpreter per arm,
+PYTHONHASHSEED=0, one ValueFunction and three AB:2 players, standard rules.
+Arm order alternates by seed. These games use Catanatron alone.
+
+| Mode | Four clean games, wall seconds | CPU seconds |
+| --- | ---: | ---: |
+| unmodified latest upstream | 43.290 | 43.273 |
+| local candidate | 12.918 | 12.911 |
+
+On clean seeds 670100000..670100003 the local candidate delivers **3.35x**
+full-game throughput (70.16% less wall time), with identical ordered action
+hashes, winners and VP in every pair. This is a four-game sample, not a broad
+performance guarantee or an isolated attribution to either commit.
+
+Separate audit seeds 670000000..670000001 match **54,372** scalar leaf values,
+ordered leaf digests/counts, all actions and outcomes against unmodified latest
+upstream. Every evaluated scalar is also checked against the frozen original
+formula. No audited deadline cutoff was observed. Audit timings are excluded
+from the speed claim; behavior can still differ on other deadline-limited
+positions because a faster engine can finish more search.
+
+## Tests and reproduction
+
+182 focused tests pass. The broader local Python 3.14 run passes 328 tests:
+
+```sh
+python -m pytest -q --benchmark-disable \
+  --ignore=tests/integration_tests/test_play.py \
+  --ignore=tests/integration_tests/test_server.py --ignore=tests/web \
+  -k 'not test_render_rgb_array'
+```
+
+The excluded tests need unavailable pandas/web/pygame dependencies. An initial
+broader run also hit one 200ms stdio-bot startup timeout; the complete supported
+selection above passed on rerun. Full optional UI/data integration validation
+remains for an environment with those dependencies before an upstream PR.
+Black 25.11.0 and git diff --check pass for changed files.
+
+`run_comparison.py` records the exact trial plan. It expects clean baseline
+and candidate exports at `/study/base` and `/study/fast`, and writable `/out`.
+It selects each source through PYTHONPATH and invokes the candidate's
+`examples/benchmark_value.py` from a fresh interpreter. `comparison.json`
+contains every child result and source fingerprint. `runtime.json` records the
+immutable image, read-only source mount, CPU limit, environment and exit.
+
+PR title: **Reduce state-copy and native evaluator overhead (building on #382)**.

--- a/docs/performance/value-speedups/README.md
+++ b/docs/performance/value-speedups/README.md
@@ -78,7 +78,7 @@ python -m pytest -q --benchmark-disable \
 The excluded tests need unavailable pandas/web/pygame dependencies. An initial
 broader run also hit one 200ms stdio-bot startup timeout; the complete supported
 selection above passed on rerun. Full optional UI/data integration validation
-remains for an environment with those dependencies before an upstream PR.
+remains for upstream CI in an environment with those dependencies.
 Black 25.11.0 and git diff --check pass for changed files.
 
 `run_comparison.py` records the exact trial plan. It expects clean baseline

--- a/docs/performance/value-speedups/comparison.json
+++ b/docs/performance/value-speedups/comparison.json
@@ -1,0 +1,258 @@
+{
+  "complete": true,
+  "equivalent": true,
+  "rows": [
+    {
+      "mode": "base",
+      "action_sha256": "dbd17d6fc229129569a2cf4283901ad5e4d90f7cd76fb9c8e68142ee164dddef",
+      "actions": 267,
+      "audit": true,
+      "cpu_seconds": 8.962805907,
+      "deadline_observations": 0,
+      "leaf_sha256": "85a3e1b910cdd173f28d964485b40ba402b8d939a89952e89152ad3f5cb66547",
+      "leaves": 27295,
+      "points": {
+        "BLUE": 6,
+        "ORANGE": 6,
+        "RED": 10,
+        "WHITE": 8
+      },
+      "python": "3.12.14 (main, Sep  1 2026, 00:10:07) [GCC 14.2.0]",
+      "seconds": 8.964627000968903,
+      "seed": 670000000,
+      "source_sha256": "d17c64ace107eae861082e75fdeda02c8f18b9f029e377881987ab768f89e7b2",
+      "winner": "RED"
+    },
+    {
+      "mode": "fast",
+      "action_sha256": "dbd17d6fc229129569a2cf4283901ad5e4d90f7cd76fb9c8e68142ee164dddef",
+      "actions": 267,
+      "audit": true,
+      "cpu_seconds": 5.404398055,
+      "deadline_observations": 0,
+      "leaf_sha256": "85a3e1b910cdd173f28d964485b40ba402b8d939a89952e89152ad3f5cb66547",
+      "leaves": 27295,
+      "points": {
+        "BLUE": 6,
+        "ORANGE": 6,
+        "RED": 10,
+        "WHITE": 8
+      },
+      "python": "3.12.14 (main, Sep  1 2026, 00:10:07) [GCC 14.2.0]",
+      "seconds": 5.409663463011384,
+      "seed": 670000000,
+      "source_sha256": "b25ccab7598c1266650fd6e0c46379bff5f822c337deb91209d6e5b110f95493",
+      "winner": "RED"
+    },
+    {
+      "mode": "fast",
+      "action_sha256": "4643597ca84871c8f4e7073894052c6616452a5935b4f4508c2e6c7a1cdc0b7d",
+      "actions": 251,
+      "audit": true,
+      "cpu_seconds": 4.866259501,
+      "deadline_observations": 0,
+      "leaf_sha256": "553e677b1bea1794c1f099da1dd9c6e6cae5e6f56a434189d791dee7ccd3bb2f",
+      "leaves": 27077,
+      "points": {
+        "BLUE": 11,
+        "ORANGE": 4,
+        "RED": 7,
+        "WHITE": 4
+      },
+      "python": "3.12.14 (main, Sep  1 2026, 00:10:07) [GCC 14.2.0]",
+      "seconds": 4.868970218114555,
+      "seed": 670000001,
+      "source_sha256": "b25ccab7598c1266650fd6e0c46379bff5f822c337deb91209d6e5b110f95493",
+      "winner": "BLUE"
+    },
+    {
+      "mode": "base",
+      "action_sha256": "4643597ca84871c8f4e7073894052c6616452a5935b4f4508c2e6c7a1cdc0b7d",
+      "actions": 251,
+      "audit": true,
+      "cpu_seconds": 7.959437192,
+      "deadline_observations": 0,
+      "leaf_sha256": "553e677b1bea1794c1f099da1dd9c6e6cae5e6f56a434189d791dee7ccd3bb2f",
+      "leaves": 27077,
+      "points": {
+        "BLUE": 11,
+        "ORANGE": 4,
+        "RED": 7,
+        "WHITE": 4
+      },
+      "python": "3.12.14 (main, Sep  1 2026, 00:10:07) [GCC 14.2.0]",
+      "seconds": 7.964358986122534,
+      "seed": 670000001,
+      "source_sha256": "d17c64ace107eae861082e75fdeda02c8f18b9f029e377881987ab768f89e7b2",
+      "winner": "BLUE"
+    },
+    {
+      "mode": "base",
+      "action_sha256": "1173d8e2564046c3afa413683b05ceaf4c324c82cae17d4c920086a068d9b80e",
+      "actions": 451,
+      "audit": false,
+      "cpu_seconds": 18.129979265,
+      "deadline_observations": null,
+      "leaf_sha256": null,
+      "leaves": null,
+      "points": {
+        "BLUE": 9,
+        "ORANGE": 5,
+        "RED": 10,
+        "WHITE": 7
+      },
+      "python": "3.12.14 (main, Sep  1 2026, 00:10:07) [GCC 14.2.0]",
+      "seconds": 18.140035412972793,
+      "seed": 670100000,
+      "source_sha256": "d17c64ace107eae861082e75fdeda02c8f18b9f029e377881987ab768f89e7b2",
+      "winner": "RED"
+    },
+    {
+      "mode": "fast",
+      "action_sha256": "1173d8e2564046c3afa413683b05ceaf4c324c82cae17d4c920086a068d9b80e",
+      "actions": 451,
+      "audit": false,
+      "cpu_seconds": 5.443910341,
+      "deadline_observations": null,
+      "leaf_sha256": null,
+      "leaves": null,
+      "points": {
+        "BLUE": 9,
+        "ORANGE": 5,
+        "RED": 10,
+        "WHITE": 7
+      },
+      "python": "3.12.14 (main, Sep  1 2026, 00:10:07) [GCC 14.2.0]",
+      "seconds": 5.445401021977887,
+      "seed": 670100000,
+      "source_sha256": "b25ccab7598c1266650fd6e0c46379bff5f822c337deb91209d6e5b110f95493",
+      "winner": "RED"
+    },
+    {
+      "mode": "fast",
+      "action_sha256": "959a64c82c12f10ef0b9fbb5bc45f935825b8a4702d75e1214c23b5fa8003c39",
+      "actions": 218,
+      "audit": false,
+      "cpu_seconds": 1.477016345,
+      "deadline_observations": null,
+      "leaf_sha256": null,
+      "leaves": null,
+      "points": {
+        "BLUE": 3,
+        "ORANGE": 10,
+        "RED": 5,
+        "WHITE": 6
+      },
+      "python": "3.12.14 (main, Sep  1 2026, 00:10:07) [GCC 14.2.0]",
+      "seconds": 1.4772520209662616,
+      "seed": 670100001,
+      "source_sha256": "b25ccab7598c1266650fd6e0c46379bff5f822c337deb91209d6e5b110f95493",
+      "winner": "ORANGE"
+    },
+    {
+      "mode": "base",
+      "action_sha256": "959a64c82c12f10ef0b9fbb5bc45f935825b8a4702d75e1214c23b5fa8003c39",
+      "actions": 218,
+      "audit": false,
+      "cpu_seconds": 4.79150744,
+      "deadline_observations": null,
+      "leaf_sha256": null,
+      "leaves": null,
+      "points": {
+        "BLUE": 3,
+        "ORANGE": 10,
+        "RED": 5,
+        "WHITE": 6
+      },
+      "python": "3.12.14 (main, Sep  1 2026, 00:10:07) [GCC 14.2.0]",
+      "seconds": 4.795602740952745,
+      "seed": 670100001,
+      "source_sha256": "d17c64ace107eae861082e75fdeda02c8f18b9f029e377881987ab768f89e7b2",
+      "winner": "ORANGE"
+    },
+    {
+      "mode": "base",
+      "action_sha256": "962ed36334cf1a7ab5192895933091a1e5d703a07ca860f1b7b86e033ed15a77",
+      "actions": 234,
+      "audit": false,
+      "cpu_seconds": 10.917754603,
+      "deadline_observations": null,
+      "leaf_sha256": null,
+      "leaves": null,
+      "points": {
+        "BLUE": 5,
+        "ORANGE": 10,
+        "RED": 2,
+        "WHITE": 5
+      },
+      "python": "3.12.14 (main, Sep  1 2026, 00:10:07) [GCC 14.2.0]",
+      "seconds": 10.91971858101897,
+      "seed": 670100002,
+      "source_sha256": "d17c64ace107eae861082e75fdeda02c8f18b9f029e377881987ab768f89e7b2",
+      "winner": "ORANGE"
+    },
+    {
+      "mode": "fast",
+      "action_sha256": "962ed36334cf1a7ab5192895933091a1e5d703a07ca860f1b7b86e033ed15a77",
+      "actions": 234,
+      "audit": false,
+      "cpu_seconds": 3.2499580139999997,
+      "deadline_observations": null,
+      "leaf_sha256": null,
+      "leaves": null,
+      "points": {
+        "BLUE": 5,
+        "ORANGE": 10,
+        "RED": 2,
+        "WHITE": 5
+      },
+      "python": "3.12.14 (main, Sep  1 2026, 00:10:07) [GCC 14.2.0]",
+      "seconds": 3.2506104719359428,
+      "seed": 670100002,
+      "source_sha256": "b25ccab7598c1266650fd6e0c46379bff5f822c337deb91209d6e5b110f95493",
+      "winner": "ORANGE"
+    },
+    {
+      "mode": "fast",
+      "action_sha256": "e59567c8313a49173b6e51f5ddbbc9b7245c27ffa62ae848d00221a3ca0d300b",
+      "actions": 254,
+      "audit": false,
+      "cpu_seconds": 2.740514036,
+      "deadline_observations": null,
+      "leaf_sha256": null,
+      "leaves": null,
+      "points": {
+        "BLUE": 8,
+        "ORANGE": 7,
+        "RED": 10,
+        "WHITE": 3
+      },
+      "python": "3.12.14 (main, Sep  1 2026, 00:10:07) [GCC 14.2.0]",
+      "seconds": 2.7444428529124707,
+      "seed": 670100003,
+      "source_sha256": "b25ccab7598c1266650fd6e0c46379bff5f822c337deb91209d6e5b110f95493",
+      "winner": "RED"
+    },
+    {
+      "mode": "base",
+      "action_sha256": "e59567c8313a49173b6e51f5ddbbc9b7245c27ffa62ae848d00221a3ca0d300b",
+      "actions": 254,
+      "audit": false,
+      "cpu_seconds": 9.433336929,
+      "deadline_observations": null,
+      "leaf_sha256": null,
+      "leaves": null,
+      "points": {
+        "BLUE": 8,
+        "ORANGE": 7,
+        "RED": 10,
+        "WHITE": 3
+      },
+      "python": "3.12.14 (main, Sep  1 2026, 00:10:07) [GCC 14.2.0]",
+      "seconds": 9.43477422813885,
+      "seed": 670100003,
+      "source_sha256": "d17c64ace107eae861082e75fdeda02c8f18b9f029e377881987ab768f89e7b2",
+      "winner": "RED"
+    }
+  ]
+}

--- a/docs/performance/value-speedups/run_comparison.py
+++ b/docs/performance/value-speedups/run_comparison.py
@@ -1,0 +1,16 @@
+import json,os,subprocess,sys
+from pathlib import Path
+rows=[]
+for audit,games,seed in ((True,2,670000000),(False,4,670100000)):
+ for i in range(games):
+  pair=[]
+  for mode in (('base','fast') if i%2==0 else ('fast','base')):
+   path=Path('/out')/f'{seed+i}-{mode}.json'
+   cmd=[sys.executable,'/study/fast/examples/benchmark_value.py','--seed',str(seed+i),'--out',str(path)]
+   if audit:cmd.append('--audit')
+   subprocess.run(cmd,env={**os.environ,'PYTHONPATH':f'/study/{mode}/catanatron'},check=True)
+   row={'mode':mode,**json.loads(path.read_text())};rows.append(row);pair.append(row)
+  fields=['seed','actions','action_sha256','winner','points']
+  if audit:fields+=['leaves','leaf_sha256','deadline_observations']
+  assert all(pair[0][key]==pair[1][key] for key in fields), pair
+  Path('/out/comparison.json').write_text(json.dumps({'complete':len(rows)==12,'equivalent':True,'rows':rows},indent=2)+'\n')

--- a/docs/performance/value-speedups/runtime.json
+++ b/docs/performance/value-speedups/runtime.json
@@ -1,0 +1,50 @@
+{
+  "Id": "d9e2bc7fb09de32734d9911df385ff10c06e344d34631b25e19d9a30a1680033",
+  "Image": "sha256:58c092875440c770999bada97e0ec7c5178b68fbe640bf3f5a131bc8a624f7be",
+  "Mounts": [
+    {
+      "Destination": "/study",
+      "Mode": "ro",
+      "Propagation": "rprivate",
+      "RW": false,
+      "Source": "/home/bsm/tmp/catanatron-upstream-ecf9311",
+      "Type": "bind"
+    },
+    {
+      "Destination": "/out",
+      "Mode": "rw",
+      "Propagation": "rprivate",
+      "RW": true,
+      "Source": "/home/bsm/tmp/catanatron-upstream-results-ecf9311",
+      "Type": "bind"
+    }
+  ],
+  "State": {
+    "Dead": false,
+    "Error": "",
+    "ExitCode": 0,
+    "FinishedAt": "2026-09-11T02:57:15.16870516Z",
+    "OOMKilled": false,
+    "Paused": false,
+    "Pid": 0,
+    "Restarting": false,
+    "Running": false,
+    "StartedAt": "2026-09-11T02:55:48.297484848Z",
+    "Status": "exited"
+  },
+  "command": [
+    "/study/run-upstream-comparison.py"
+  ],
+  "env": [
+    "OMP_NUM_THREADS=1",
+    "OPENBLAS_NUM_THREADS=1",
+    "MKL_NUM_THREADS=1",
+    "PYTHONHASHSEED=0",
+    "PYTHONPATH=/app/src"
+  ],
+  "runtime": {
+    "NanoCpus": 1000000000,
+    "NetworkMode": "none"
+  },
+  "user": "1000:1000"
+}

--- a/examples/benchmark_value.py
+++ b/examples/benchmark_value.py
@@ -1,0 +1,101 @@
+"""Fresh-process full-game check; compare JSON from base and candidate checkouts.
+
+Run with PYTHONHASHSEED=0. --audit checks every scalar against the frozen
+pre-optimization evaluator and records leaf order and search deadline cutoffs.
+Use disjoint seeds for clean timing and audits. This uses only Catanatron.
+"""
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+import runpy
+import sys
+import time
+
+from catanatron.game import Game
+from catanatron.models.player import Color
+from catanatron.players import minimax, value
+from catanatron.state_functions import player_key
+
+parser = argparse.ArgumentParser(description=__doc__)
+parser.add_argument("--seed", type=int, required=True)
+parser.add_argument("--audit", action="store_true")
+parser.add_argument("--out", type=Path, required=True)
+args = parser.parse_args()
+if args.out.exists():
+    parser.error("output exists")
+leaves, deadlines = 0, 0
+leaf_digest = hashlib.sha256()
+if args.audit:
+    reference = runpy.run_path(
+        str(Path(__file__).resolve().parents[1] / "tests/value_reference.py")
+    )["reference_base_fn"]
+    original = value.base_fn
+
+    def factory(params=value.DEFAULT_WEIGHTS, **kwargs):
+        fast, native = original(params, **kwargs), reference(params)
+
+        def evaluate(game, color):
+            global leaves
+            actual = fast(game, color)
+            expected = native(game, color)
+            assert actual == expected, (actual, expected)
+            leaves += 1
+            leaf_digest.update(actual.hex().encode() + b"\0")
+            return actual
+
+        return evaluate
+
+    value.base_fn = factory
+    original_alpha = minimax.AlphaBetaPlayer.alphabeta
+
+    def alpha(self, game, depth, low, high, deadline, node):
+        global deadlines
+        if depth > 0 and game.winning_color() is None and time.time() >= deadline:
+            deadlines += 1
+        return original_alpha(self, game, depth, low, high, deadline, node)
+
+    minimax.AlphaBetaPlayer.alphabeta = alpha
+players = [value.ValueFunctionPlayer(Color.RED)] + [
+    minimax.AlphaBetaPlayer(c) for c in list(Color)[1:]
+]
+wall, cpu = time.perf_counter(), time.process_time()
+game = Game(players, seed=args.seed)
+winner = game.play()
+seconds, cpu_seconds = time.perf_counter() - wall, time.process_time() - cpu
+assert winner is not None
+import catanatron
+
+source = hashlib.sha256()
+root = Path(catanatron.__file__).parent
+for path in sorted(root.rglob("*.py")):
+    source.update(
+        path.relative_to(root).as_posix().encode() + b"\0" + path.read_bytes() + b"\0"
+    )
+r = {
+    "seed": args.seed,
+    "audit": args.audit,
+    "seconds": seconds,
+    "cpu_seconds": cpu_seconds,
+    "python": sys.version,
+    "source_sha256": source.hexdigest(),
+    "winner": winner.value,
+    "points": {
+        c.value: game.state.player_state[
+            player_key(game.state, c) + "_ACTUAL_VICTORY_POINTS"
+        ]
+        for c in Color
+    },
+    "actions": len(game.state.action_records),
+    "action_sha256": hashlib.sha256(
+        json.dumps([repr(x) for x in game.state.action_records]).encode()
+    ).hexdigest(),
+    "leaves": leaves if args.audit else None,
+    "leaf_sha256": leaf_digest.hexdigest() if args.audit else None,
+    "deadline_observations": deadlines if args.audit else None,
+}
+args.out.parent.mkdir(parents=True, exist_ok=True)
+args.out.write_text(json.dumps(r, indent=2, sort_keys=True) + "\n")
+print(json.dumps(r), flush=True)
+assert not deadlines, "deadline-limited audit cannot establish equivalence"

--- a/tests/test_value_performance.py
+++ b/tests/test_value_performance.py
@@ -1,0 +1,176 @@
+"""Exact evaluator output and mutable-copy contracts for the speed changes."""
+
+import pickle
+import random
+from collections import defaultdict
+
+import pytest
+
+from catanatron.game import Game
+from catanatron.models.enums import SETTLEMENT, CITY
+from catanatron.models.player import Color, RandomPlayer
+from catanatron.features import reachability_features
+from catanatron.players.value import base_fn, DEFAULT_WEIGHTS, BoardFeatureCache
+from tests.value_reference import reference_base_fn
+
+
+def position(seed=17):
+    return Game([RandomPlayer(c) for c in Color], seed=seed)
+
+
+@pytest.mark.parametrize("cached", [False, True])
+def test_exact_scalar_for_every_perspective_and_nondefault_weights(cached):
+    varied = {key: (i + 1) / 7 for i, key in enumerate(DEFAULT_WEIGHTS)}
+    cache = BoardFeatureCache() if cached else None
+    evaluators = [
+        (base_fn(p, cache=cache), reference_base_fn(p))
+        for p in (DEFAULT_WEIGHTS, varied)
+    ]
+    for seed in (7, 19):
+        game = position(seed)
+        rng = random.Random(seed)
+        for tick in range(300):
+            if tick % 7 == 0:
+                for color in game.state.colors:
+                    for actual, reference in evaluators:
+                        assert actual(game, color) == reference(game, color)
+                    full = reachability_features(game, color, 2)
+                    subset = reachability_features(game, color, 1, only_p0=True)
+                    assert len(subset) == 10
+                    assert all(full[k] == v for k, v in subset.items())
+            if game.winning_color() is not None:
+                break
+            game.execute(rng.choice(game.playable_actions))
+
+
+def test_board_copy_matches_nested_container_values_order_and_isolation():
+    board = position().state.board
+    color = Color.RED
+    board.connected_components[color] = [{0, 1}, {3, 4}]
+    board.buildable_edges_cache[color] = [(0, 1), (3, 4)]
+    board.player_port_resources_cache[color] = {"WOOD", "ORE"}
+    original = pickle.loads(pickle.dumps(board.connected_components))
+    copied = board.copy()
+    assert vars(copied) == vars(board)
+    assert isinstance(copied.connected_components, defaultdict)
+    assert (
+        copied.connected_components.default_factory
+        is board.connected_components.default_factory
+    )
+    assert [list(c) for c in copied.connected_components[color]] == [
+        list(c) for c in original[color]
+    ]
+    for name in ("map", "buildable_subgraph"):
+        assert getattr(copied, name) is getattr(board, name)
+    for name in (
+        "buildings",
+        "roads",
+        "connected_components",
+        "board_buildable_ids",
+        "road_lengths",
+        "buildable_edges_cache",
+        "player_port_resources_cache",
+    ):
+        assert getattr(copied, name) is not getattr(board, name)
+    copied.connected_components[color][0].add(9)
+    copied.buildable_edges_cache[color].append((8, 9))
+    copied.player_port_resources_cache[color].add("SHEEP")
+    assert board.connected_components[color][0] == {0, 1}
+    assert board.buildable_edges_cache[color] == [(0, 1), (3, 4)]
+    assert board.player_port_resources_cache[color] == {"WOOD", "ORE"}
+
+
+def test_state_copy_preserves_rng_and_nested_building_contract():
+    state = position().state
+    color = state.colors[0]
+    state.buildings_by_color[color][SETTLEMENT].extend([1, 3])
+    state.buildings_by_color[color][CITY].append(5)
+    expected = pickle.loads(pickle.dumps(state.buildings_by_color))
+    copied = state.copy()
+    assert set(vars(copied)) == set(vars(state))
+    for name in vars(state):
+        if name != "board":
+            assert getattr(copied, name) == getattr(state, name)
+    assert copied.random is state.random
+    assert copied.players is state.players
+    assert copied.colors is state.colors
+    assert copied.buildings_by_color == expected
+    for c, buildings in state.buildings_by_color.items():
+        assert copied.buildings_by_color[c] is not buildings
+        assert isinstance(copied.buildings_by_color[c], defaultdict)
+        assert copied.buildings_by_color[c].default_factory is buildings.default_factory
+        for kind, nodes in buildings.items():
+            assert copied.buildings_by_color[c][kind] is not nodes
+    copied.buildings_by_color[color][SETTLEMENT].append(7)
+    assert state.buildings_by_color == expected
+
+
+def test_cache_reads_dynamic_hand_points_and_longest_road_live():
+    game = position()
+    cache = BoardFeatureCache()
+    fast = base_fn(cache=cache)
+    native = reference_base_fn()
+    color = game.state.colors[0]
+    first = fast(game, color)
+    for suffix, delta in (
+        ("WHEAT_IN_HAND", 8),
+        ("VICTORY_POINTS", 1),
+        ("LONGEST_ROAD_LENGTH", 2),
+        ("KNIGHT_IN_HAND", 1),
+        ("PLAYED_KNIGHT", 1),
+    ):
+        key = "P0_" + suffix
+        game.state.player_state[key] += delta
+        assert fast(game, color) == native(game, color)
+    assert fast(game, color) != first
+    assert cache.misses == 1
+    assert cache.hits > 1
+
+
+def test_cache_invalidates_board_dependencies_and_bounds_memory():
+    game = position()
+    cache = BoardFeatureCache(max_entries=2)
+    color = game.state.colors[0]
+    cache.terms(game, color)
+    board = game.state.board
+    # Independent mutable dependencies, even when the resulting synthetic
+    # state has redundant representations that are not mutually consistent.
+    mutations = (
+        lambda: setattr(
+            board,
+            "robber_coordinate",
+            next(c for c in board.map.land_tiles if c != board.robber_coordinate),
+        ),
+        lambda: game.state.buildings_by_color[color][SETTLEMENT].append(0),
+        lambda: game.state.buildings_by_color[color][CITY].append(1),
+        lambda: board.buildings.update({0: (game.state.colors[1], SETTLEMENT)}),
+        lambda: board.roads.update({(0, 1): game.state.colors[1]}),
+        lambda: board.connected_components[color].append({0, 1}),
+        lambda: board.board_buildable_ids.discard(0),
+    )
+    for mutate in mutations:
+        before = cache.misses
+        mutate()
+        cached = cache.terms(game, color)
+        assert cache.misses == before + 1
+        assert cached == BoardFeatureCache().terms(game, color)
+        assert len(cache.entries) <= 2
+    other = position(18)
+    cache.terms(other, other.state.colors[0])
+    assert cache.map is other.state.board.map
+    assert len(cache.entries) == 1
+
+
+def test_player_caches_are_isolated_and_follow_game_changes():
+    from catanatron.players.minimax import AlphaBetaPlayer
+    from catanatron.players.value import ValueFunctionPlayer
+
+    first = AlphaBetaPlayer(Color.RED)
+    second = ValueFunctionPlayer(Color.BLUE)
+    assert first._board_feature_cache is not second._board_feature_cache
+    assert first._board_feature_cache is first._board_feature_cache
+    for seed in (1, 2):
+        game = position(seed)
+        first._board_feature_cache.terms(game, Color.RED)
+        assert first._board_feature_cache.map is game.state.board.map
+        assert len(first._board_feature_cache.entries) == 1

--- a/tests/value_reference.py
+++ b/tests/value_reference.py
@@ -1,0 +1,83 @@
+# Frozen upstream scalar evaluator at ecf931181b9a65bb4116a2153fb78c16f1438e00.
+# Keep arithmetic independent of the optimized implementation.
+from catanatron.players.value import DEFAULT_WEIGHTS, value_production
+from catanatron.features import (
+    build_production_features,
+    reachability_features,
+    resource_hand_features,
+)
+from catanatron.models.enums import RESOURCES, SETTLEMENT, CITY
+from catanatron.state_functions import (
+    player_key,
+    get_longest_road_length,
+    player_num_resource_cards,
+    player_num_dev_cards,
+    get_played_dev_cards,
+)
+
+
+def reference_base_fn(params=DEFAULT_WEIGHTS):
+    def fn(game, p0_color):
+        production_features = build_production_features(True)
+        our_production_sample = production_features(game, p0_color)
+        enemy_production_sample = production_features(game, p0_color)
+        production = value_production(our_production_sample, "P0")
+        enemy_production = value_production(enemy_production_sample, "P1", False)
+
+        key = player_key(game.state, p0_color)
+        longest_road_length = get_longest_road_length(game.state, p0_color)
+
+        reachability_sample = reachability_features(game, p0_color, 2)
+        features = [f"P0_0_ROAD_REACHABLE_{resource}" for resource in RESOURCES]
+        reachable_production_at_zero = sum([reachability_sample[f] for f in features])
+        features = [f"P0_1_ROAD_REACHABLE_{resource}" for resource in RESOURCES]
+        reachable_production_at_one = sum([reachability_sample[f] for f in features])
+
+        hand_sample = resource_hand_features(game, p0_color)
+        features = [f"P0_{resource}_IN_HAND" for resource in RESOURCES]
+        distance_to_city = (
+            max(2 - hand_sample["P0_WHEAT_IN_HAND"], 0)
+            + max(3 - hand_sample["P0_ORE_IN_HAND"], 0)
+        ) / 5.0  # 0 means good. 1 means bad.
+        distance_to_settlement = (
+            max(1 - hand_sample["P0_WHEAT_IN_HAND"], 0)
+            + max(1 - hand_sample["P0_SHEEP_IN_HAND"], 0)
+            + max(1 - hand_sample["P0_BRICK_IN_HAND"], 0)
+            + max(1 - hand_sample["P0_WOOD_IN_HAND"], 0)
+        ) / 4.0  # 0 means good. 1 means bad.
+        hand_synergy = (2 - distance_to_city - distance_to_settlement) / 2
+
+        num_in_hand = player_num_resource_cards(game.state, p0_color)
+        discard_penalty = params["discard_penalty"] if num_in_hand > 7 else 0
+
+        # blockability
+        buildings = game.state.buildings_by_color[p0_color]
+        owned_nodes = buildings[SETTLEMENT] + buildings[CITY]
+        owned_tiles = set()
+        for n in owned_nodes:
+            owned_tiles.update(game.state.board.map.adjacent_tiles[n])
+        num_tiles = len(owned_tiles)
+
+        # TODO: Simplify to linear(?)
+        num_buildable_nodes = len(game.state.board.buildable_node_ids(p0_color))
+        longest_road_factor = (
+            params["longest_road"] if num_buildable_nodes == 0 else 0.1
+        )
+
+        return float(
+            game.state.player_state[f"{key}_VICTORY_POINTS"] * params["public_vps"]
+            + production * params["production"]
+            + enemy_production * params["enemy_production"]
+            + reachable_production_at_zero * params["reachable_production_0"]
+            + reachable_production_at_one * params["reachable_production_1"]
+            + hand_synergy * params["hand_synergy"]
+            + num_buildable_nodes * params["buildable_nodes"]
+            + num_tiles * params["num_tiles"]
+            + num_in_hand * params["hand_resources"]
+            + discard_penalty
+            + longest_road_length * longest_road_factor
+            + player_num_dev_cards(game.state, p0_color) * params["hand_devs"]
+            + get_played_dev_cards(game.state, p0_color, "KNIGHT") * params["army_size"]
+        )
+
+    return fn


### PR DESCRIPTION
Extends #382 by eliminating redundant serializations and feature recomputations for AB and ValueFunction players.
 * Replaces repeated deep copies of small mutable containers with structural copies.
 * Restricts the scalar evaluator to request only consumed features rather than computing full defaults.
 * Adds a per-player board-feature cache that clears automatically on map or seating changes.

## Validation
 * 3.35× throughput (43.290s to 12.918s across four paired complete games) measured against current main (ecf9311) on Python 3.12, incorporating #382's optimization.
 * Verified across 54,372 audited scalar leaf values matching a frozen pre-change control, with all 328 local tests passing.
